### PR TITLE
[Windows port] 1/8: UTF-8-safe CLI helper output (Windows cp1252)

### DIFF
--- a/skills/shadow-frog-dream/dream-validate.py
+++ b/skills/shadow-frog-dream/dream-validate.py
@@ -33,6 +33,9 @@ import sys
 
 
 def main():
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     args = sys.argv[1:]
 
     if not args or args[0] in ('--help', '-h'):
@@ -97,7 +100,7 @@ def main():
 
     # 5. Validate report dream_id
     report_path = os.path.join(dream_dir, 'report.md')
-    with open(report_path) as f:
+    with open(report_path, encoding="utf-8") as f:
         content = f.read()
     m = re.match(r'^\ufeff?\s*---\r?\n(.*?)\r?\n---', content, re.S)
     if m:
@@ -115,7 +118,7 @@ def main():
     # 6. Validate manifest
     manifest_path = os.path.join(dream_dir, 'manifest.json')
     try:
-        with open(manifest_path) as f:
+        with open(manifest_path, encoding="utf-8") as f:
             manifest = json.load(f)
     except json.JSONDecodeError as e:
         errors.append(f"manifest.json is invalid JSON: {e}")
@@ -211,7 +214,7 @@ def main():
                 d = subprocess.run(
                     ['git', '-C', worktree, 'diff', '--name-only',
                      '--relative', f'{base}..HEAD', '--', '.shadow/'],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True, text=True, encoding="utf-8", timeout=10,
                 )
                 if d.returncode == 0:
                     if d.stdout:
@@ -231,7 +234,7 @@ def main():
                 s = subprocess.run(
                     ['git', '-C', worktree, 'status', '--porcelain=v1',
                      '--untracked-files=all', '--', '.shadow/'],
-                    capture_output=True, text=True, timeout=10,
+                    capture_output=True, text=True, encoding="utf-8", timeout=10,
                 )
                 if s.returncode == 0:
                     for line in s.stdout.strip().splitlines():

--- a/skills/shadow-frog-viewer/dream-lineage.py
+++ b/skills/shadow-frog-viewer/dream-lineage.py
@@ -73,7 +73,7 @@ def load_index(shadow_dir):
     branch_by_slug = {}
 
     # First pass: collect all branches and build slug index
-    with open(index_path) as f:
+    with open(index_path, encoding="utf-8") as f:
         for line in f:
             parts = [p.strip() for p in line.split("|")]
             if len(parts) < 8:
@@ -91,7 +91,7 @@ def load_index(shadow_dir):
                 branch_by_slug[branch[slug_match.start():]] = branch
 
     # Second pass: resolve parent references (handle timestamp mismatches)
-    with open(index_path) as f:
+    with open(index_path, encoding="utf-8") as f:
         for line in f:
             parts = [p.strip() for p in line.split("|")]
             if len(parts) < 8:
@@ -119,7 +119,7 @@ def load_index(shadow_dir):
         manifest_path = os.path.join(dreams_dir, did, "manifest.json")
         if os.path.exists(manifest_path):
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding="utf-8") as f:
                     mdata = json.load(f)
                 mp = mdata.get("parent_branch", "")
             except Exception:
@@ -129,7 +129,7 @@ def load_index(shadow_dir):
             report_path = os.path.join(dreams_dir, did, "report.md")
             if os.path.exists(report_path):
                 try:
-                    with open(report_path) as f:
+                    with open(report_path, encoding="utf-8") as f:
                         head = f.read(2000)
                     # Check builds_on in frontmatter
                     m = re.search(r"builds_on:\s*\[?\s*[\"']?([^\]\"'\n,]+)", head)
@@ -182,7 +182,7 @@ def load_reports(shadow_dir, meta):
 
         if os.path.exists(report_path):
             try:
-                with open(report_path) as f:
+                with open(report_path, encoding="utf-8") as f:
                     content = f.read()
                 body = content
                 if content.startswith("---"):
@@ -196,7 +196,7 @@ def load_reports(shadow_dir, meta):
         manifest_path = os.path.join(shadow_dir, "_dreams", did, "manifest.json")
         if os.path.exists(manifest_path):
             try:
-                with open(manifest_path) as f:
+                with open(manifest_path, encoding="utf-8") as f:
                     mdata = json.load(f)
                 info["tests"] = str(mdata.get("tests_passed", mdata.get("test_count", "")))
                 info["discoveries_count"] = len(mdata.get("discoveries", []))
@@ -545,7 +545,7 @@ def generate_html(shadow_dir, output_path):
         templates=templates_html,
     )
 
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(page)
     print(f"Wrote {output_path} ({os.path.getsize(output_path):,} bytes)")
     print(f"  {total} experiments, {len(chain_roots)} chains (max depth {max_depth}), "

--- a/skills/shadow-frog-viewer/shadow-viewer.py
+++ b/skills/shadow-frog-viewer/shadow-viewer.py
@@ -1250,6 +1250,9 @@ def view_check_invariants(shadow_dir):
 
 
 def main():
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     try:
         parser = argparse.ArgumentParser(
             description="Query and browse a .shadow/ knowledge base.",

--- a/tests/skills/shadow_frog_dream/test_dream_validate.py
+++ b/tests/skills/shadow_frog_dream/test_dream_validate.py
@@ -36,14 +36,14 @@ def _git_env(home: Path) -> dict:
 
 def _run(cmd, cwd, env=None, check=True):
     return subprocess.run(
-        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=check
+        cmd, cwd=cwd, env=env, capture_output=True, text=True, encoding="utf-8", check=check
     )
 
 
 def _commit_base(repo: Path) -> str:
     """Seed initial commit. Returns the base SHA (full)."""
     env = _git_env(repo)
-    (repo / "README.md").write_text("# base\n")
+    (repo / "README.md").write_text("# base\n", encoding="utf-8")
     _run(["git", "add", "-A"], cwd=repo, env=env)
     _run(["git", "commit", "-q", "-m", "base"], cwd=repo, env=env)
     return _run(["git", "rev-parse", "HEAD"], cwd=repo, env=env).stdout.strip()
@@ -53,7 +53,7 @@ def _run_validate(dream_id: str, worktree: Path) -> subprocess.CompletedProcess:
     """Invoke dream-validate.py as a subprocess; never raises on non-zero."""
     return subprocess.run(
         [sys.executable, str(SCRIPT), dream_id, str(worktree)],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
 
 
@@ -98,10 +98,10 @@ def _write_dream(
     d = worktree / ".shadow" / "_dreams" / dream_id
     d.mkdir(parents=True, exist_ok=True)
     if manifest is not None:
-        (d / "manifest.json").write_text(json.dumps(manifest, indent=2))
+        (d / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     if report is not None:
-        (d / "report.md").write_text(report)
-    (d / "patch.diff").write_text(patch)
+        (d / "report.md").write_text(report, encoding="utf-8")
+    (d / "patch.diff").write_text(patch, encoding="utf-8")
     return d
 
 
@@ -114,7 +114,7 @@ def _write_dream(
 def test_help_exits_zero():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--help"],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     assert result.returncode == 0
     assert "Validate dream artifacts" in result.stdout
@@ -125,7 +125,7 @@ def test_help_exits_zero():
 def test_no_args_exits_nonzero_and_prints_usage():
     result = subprocess.run(
         [sys.executable, str(SCRIPT)],
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     assert result.returncode == 1
     assert "Usage" in result.stdout or "Validate dream artifacts" in result.stdout
@@ -149,7 +149,7 @@ def test_missing_manifest_and_report_fails(tmp_git_repo):
     dream_id = "20260101-000000Z-missing"
     d = tmp_git_repo / ".shadow" / "_dreams" / dream_id
     d.mkdir(parents=True, exist_ok=True)
-    (d / "patch.diff").write_text("diff\n")
+    (d / "patch.diff").write_text("diff\n", encoding="utf-8")
     # No report.md, no manifest.json.
 
     result = _run_validate(dream_id, tmp_git_repo)
@@ -166,7 +166,7 @@ def test_flat_file_fails(tmp_git_repo):
     dream_id = "20260101-000000Z-flat"
     dreams = tmp_git_repo / ".shadow" / "_dreams"
     dreams.mkdir(parents=True, exist_ok=True)
-    (dreams / f"{dream_id}.md").write_text("# flat\n")  # forbidden
+    (dreams / f"{dream_id}.md").write_text("# flat\n", encoding="utf-8")  # forbidden
 
     result = _run_validate(dream_id, tmp_git_repo)
     assert result.returncode == 1
@@ -343,7 +343,7 @@ def _mirror_shadow(repo: Path, source_rel: str, base_sha: str):
     """
     shadow = repo / ".shadow" / (source_rel + ".md")
     shadow.parent.mkdir(parents=True, exist_ok=True)
-    shadow.write_text("## `y`\n\n- mirrored discovery\n")
+    shadow.write_text("## `y`\n\n- mirrored discovery\n", encoding="utf-8")
 
 
 # ===========================================================================

--- a/tests/skills/shadow_frog_viewer/test_dream_lineage.py
+++ b/tests/skills/shadow_frog_viewer/test_dream_lineage.py
@@ -197,7 +197,7 @@ class TestLoadIndex:
             "| 20250101-120000Z-base | investigation | useful | Base exp | dream/proj/20250101-120000Z-base | main | abc1234 |\n"
             "| 20250102-120000Z-extend | investigation | useful | Extend exp | dream/proj/20250102-120000Z-extend | dream/proj/20250101-120000Z-base | def5678 |\n"
         )
-        (dreams / "_index.md").write_text(index_content)
+        (dreams / "_index.md").write_text(index_content, encoding="utf-8")
         # Create minimal dream dirs
         (dreams / "20250101-120000Z-base").mkdir()
         (dreams / "20250102-120000Z-extend").mkdir()
@@ -222,7 +222,7 @@ class TestLoadIndex:
             "| 20250101-120000Z-t01-base | investigation | useful | Base | dream/proj/20250101-120000Z-t01-base | main | abc1234 |\n"
             "| 20250102-120000Z-t02-child | investigation | useful | Child | dream/proj/20250102-120000Z-t02-child | dream/proj/99999999-999999Z-t01-base | def5678 |\n"
         )
-        (dreams / "_index.md").write_text(index_content)
+        (dreams / "_index.md").write_text(index_content, encoding="utf-8")
         (dreams / "20250101-120000Z-t01-base").mkdir()
         (dreams / "20250102-120000Z-t02-child").mkdir()
 
@@ -249,10 +249,10 @@ class TestLoadReports:
             "---\ndream_id: \"20250101-120000Z-test\"\ncategory: investigation\n"
             "verdict: useful\n---\n\n# Test Experiment\n\nBody content here.\n"
         )
-        (dream_dir / "report.md").write_text(report)
+        (dream_dir / "report.md").write_text(report, encoding="utf-8")
 
         manifest = {"verdict": "useful", "tests_passed": 5, "discoveries": ["a", "b"]}
-        (dream_dir / "manifest.json").write_text(json.dumps(manifest))
+        (dream_dir / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
         branch = "dream/proj/20250101-120000Z-test"
         meta = {branch: {"did": did}}
@@ -273,7 +273,7 @@ class TestCLI:
     def test_help_exits_zero(self):
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--help"],
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8",
         )
         assert result.returncode == 0
         assert "Dream lineage" in result.stdout or "output" in result.stdout.lower()
@@ -283,7 +283,7 @@ class TestCLI:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "-o", str(out_file),
              "--shadow-dir", str(coupon_demo / ".shadow")],
-            capture_output=True, text=True,
+            capture_output=True, text=True, encoding="utf-8",
             cwd=str(coupon_demo),
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
@@ -295,9 +295,9 @@ class TestCLI:
         subprocess.run(
             [sys.executable, str(SCRIPT), "-o", str(out_file),
              "--shadow-dir", str(coupon_demo / ".shadow")],
-            capture_output=True, text=True, cwd=str(coupon_demo), check=True,
+            capture_output=True, text=True, encoding="utf-8", cwd=str(coupon_demo), check=True,
         )
-        content = out_file.read_text()
+        content = out_file.read_text(encoding="utf-8")
 
         # Parse with HTMLParser — should not raise
         errors = []
@@ -349,11 +349,11 @@ def _build_dreams(shadow_dir: Path, rows, reports=None, manifests=None):
             f"| {did} | {cat} | {verdict} | {title} | {branch} | {parent} | {tip} |"
         )
         (dreams / did).mkdir(exist_ok=True)
-    (dreams / "_index.md").write_text(header + "\n".join(body_lines) + "\n")
+    (dreams / "_index.md").write_text(header + "\n".join(body_lines) + "\n", encoding="utf-8")
     for did, text in (reports or {}).items():
-        (dreams / did / "report.md").write_text(text)
+        (dreams / did / "report.md").write_text(text, encoding="utf-8")
     for did, data in (manifests or {}).items():
-        (dreams / did / "manifest.json").write_text(json.dumps(data))
+        (dreams / did / "manifest.json").write_text(json.dumps(data), encoding="utf-8")
     return dreams
 
 
@@ -548,7 +548,7 @@ class TestGenerateHtmlCouponDemo:
         dream_lineage.generate_html(str(coupon_demo / ".shadow"), str(out))
         # capture but don't fail on console output
         capsys.readouterr()
-        return out.read_text()
+        return out.read_text(encoding="utf-8")
 
     def test_writes_non_empty_file(self, dream_lineage, coupon_demo, tmp_path):
         out = tmp_path / "lineage.html"
@@ -652,7 +652,7 @@ class TestGenerateHtmlEdgeCases:
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
 
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         assert html.startswith("<!DOCTYPE html>")
         # Zero experiments dashboard
         assert ">0<" in html
@@ -683,7 +683,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         # The short name should still appear in the rendered shell
         assert "ghost" in html
         # No template since report.md was never created
@@ -706,14 +706,14 @@ class TestGenerateHtmlEdgeCases:
             "\n"
             "trailing prose line that is not a table row\n"
         )
-        (dreams / "_index.md").write_text(content)
+        (dreams / "_index.md").write_text(content, encoding="utf-8")
         (dreams / "20250101-120000Z-ok").mkdir()
 
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         msg = capsys.readouterr().out
         assert "1 experiments" in msg
-        assert "ok" in out.read_text()
+        assert "ok" in out.read_text(encoding="utf-8")
 
     def test_lineage_chain_renders_both_ancestors(self, dream_lineage, tmp_path, capsys):
         """A → B → C chain: all 3 short names appear and chain count = 1."""
@@ -732,7 +732,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         msg = capsys.readouterr().out
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
 
         # Chain depth: 3-node chain = 1 root with depth 2 → max_depth = 3
         assert "1 chains" in msg
@@ -802,7 +802,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         assert html.count('class="fresh-group"') == 3
         # Dead-end ❌ rendered
         assert "❌" in html
@@ -820,7 +820,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         # The "Unknown" cat-stat block
         assert "Unknown" in html
 
@@ -841,7 +841,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         # template body contains markdown→html output
         assert "<template id=" in html
         assert "<h2>Big Heading</h2>" in html
@@ -862,7 +862,7 @@ class TestGenerateHtmlEdgeCases:
         out = tmp_path / "out.html"
         dream_lineage.generate_html(str(shadow), str(out))
         capsys.readouterr()
-        html = out.read_text()
+        html = out.read_text(encoding="utf-8")
         # 3 sessions: 20250101-1200, 20250101-1259, 20250102-0800
         m = re.search(r'<div class="num">(\d+)</div><div class="label">Sessions</div>', html)
         assert m and m.group(1) == "3"
@@ -881,7 +881,7 @@ class TestCLIMain:
         result = subprocess.run(
             [sys.executable, str(SCRIPT),
              "--shadow-dir", str(coupon_demo / ".shadow")],
-            capture_output=True, text=True, cwd=str(coupon_demo),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(coupon_demo),
         )
         assert result.returncode == 0, result.stderr
         default = coupon_demo / "dream-lineage.html"
@@ -895,18 +895,18 @@ class TestCLIMain:
             [sys.executable, str(SCRIPT),
              "-o", str(target),
              "--shadow-dir", str(coupon_demo / ".shadow")],
-            capture_output=True, text=True, cwd=str(coupon_demo),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(coupon_demo),
         )
         assert result.returncode == 0, result.stderr
         assert target.exists()
-        assert target.read_text().startswith("<!DOCTYPE html>")
+        assert target.read_text(encoding="utf-8").startswith("<!DOCTYPE html>")
 
     def test_shadow_dir_auto_detect_from_cwd(self, coupon_demo):
         # When --shadow-dir is omitted, find_shadow_dir scans cwd for .shadow
         out_file = coupon_demo / "auto.html"
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "-o", str(out_file)],
-            capture_output=True, text=True, cwd=str(coupon_demo),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(coupon_demo),
         )
         assert result.returncode == 0, result.stderr
         assert out_file.exists()
@@ -917,7 +917,7 @@ class TestCLIMain:
         empty.mkdir()
         result = subprocess.run(
             [sys.executable, str(SCRIPT)],
-            capture_output=True, text=True, cwd=str(empty),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(empty),
         )
         assert result.returncode == 1
         assert "ERROR" in result.stderr
@@ -928,7 +928,7 @@ class TestCLIMain:
             [sys.executable, str(SCRIPT),
              "-o", str(out_file),
              "--shadow-dir", str(coupon_demo / ".shadow")],
-            capture_output=True, text=True, cwd=str(coupon_demo),
+            capture_output=True, text=True, encoding="utf-8", cwd=str(coupon_demo),
         )
         assert result.returncode == 0
         assert "3 experiments" in result.stdout
@@ -985,7 +985,8 @@ class TestTreeDepthCycleGuard:
             "| dream_id | category | verdict | title | branch | parent | tip_commit |\n"
             "|----------|----------|---------|-------|--------|--------|------------|\n"
             "| ida | exploration | useful | T-A | dream/proj/A | dream/proj/B | abc |\n"
-            "| idb | exploration | useful | T-B | dream/proj/B | dream/proj/A | def |\n"
+            "| idb | exploration | useful | T-B | dream/proj/B | dream/proj/A | def |\n",
+            encoding="utf-8",
         )
         out = tmp_path / "lineage.html"
         dream_lineage.generate_html(shadow, out)

--- a/tests/skills/shadow_frog_viewer/test_shadow_viewer.py
+++ b/tests/skills/shadow_frog_viewer/test_shadow_viewer.py
@@ -53,6 +53,7 @@ def _run_viewer(repo_root, cwd, *args):
         cwd=str(cwd),
         capture_output=True,
         text=True,
+        encoding="utf-8",
         check=False,
     )
 

--- a/tests/test_cp1252_output_regression.py
+++ b/tests/test_cp1252_output_regression.py
@@ -1,18 +1,19 @@
-"""Regression: the CLI helpers must stay UTF-8-safe under a narrow (cp1252)
-codec, not only on a UTF-8 platform.
+"""The CLI helpers must stay UTF-8-safe under a narrow (cp1252) codec, not only
+on a UTF-8 platform.
 
-Linux/macOS default to UTF-8, so the Windows ``cp1252`` failure is invisible
-in the normal Linux CI. These tests force the narrow-codec failure mode on
-*any* OS:
+Linux/macOS default to UTF-8, so a missing explicit encoding only fails where
+the platform default codec is narrow (e.g. Windows ``cp1252``). These tests
+force that narrow-codec failure mode on *any* OS:
 
-  * ``PYTHONIOENCODING=cp1252`` pins a Windows-style narrow stdout codec
-    (covers the stdout ``reconfigure`` fix).
-  * ``LC_ALL=C`` + ``PYTHONUTF8=0`` makes the default *file* encoding narrow on
-    POSIX too (covers the ``open(..., encoding="utf-8")`` fix); on Windows the
-    ANSI code page already makes it ``cp1252``.
+  * ``PYTHONIOENCODING=cp1252`` pins a narrow stdout/stderr codec, exercising
+    the streams' ``reconfigure(encoding="utf-8")`` path.
+  * ``LC_ALL=C`` + ``PYTHONUTF8=0`` makes the default *file* codec narrow on
+    POSIX too, exercising the explicit ``encoding="utf-8"`` on file and
+    subprocess I/O; on Windows the ANSI code page already makes it ``cp1252``.
 
-Without the Phase-1 fixes each helper raises ``UnicodeEncodeError`` /
-``UnicodeDecodeError`` and exits non-zero; with them, both pass everywhere.
+A helper that emits non-ASCII without pinning UTF-8 raises
+``UnicodeEncodeError`` / ``UnicodeDecodeError`` here and exits non-zero; with
+UTF-8 pinned, both pass on every platform.
 """
 import os
 import subprocess

--- a/tests/test_cp1252_output_regression.py
+++ b/tests/test_cp1252_output_regression.py
@@ -1,0 +1,64 @@
+"""Regression: the CLI helpers must stay UTF-8-safe under a narrow (cp1252)
+codec, not only on a UTF-8 platform.
+
+Linux/macOS default to UTF-8, so the Windows ``cp1252`` failure is invisible
+in the normal Linux CI. These tests force the narrow-codec failure mode on
+*any* OS:
+
+  * ``PYTHONIOENCODING=cp1252`` pins a Windows-style narrow stdout codec
+    (covers the stdout ``reconfigure`` fix).
+  * ``LC_ALL=C`` + ``PYTHONUTF8=0`` makes the default *file* encoding narrow on
+    POSIX too (covers the ``open(..., encoding="utf-8")`` fix); on Windows the
+    ANSI code page already makes it ``cp1252``.
+
+Without the Phase-1 fixes each helper raises ``UnicodeEncodeError`` /
+``UnicodeDecodeError`` and exits non-zero; with them, both pass everywhere.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+DEMO_SHADOW = REPO / "examples" / "coupon-demo" / ".shadow"
+VIEWER = REPO / "skills" / "shadow-frog-viewer" / "shadow-viewer.py"
+LINEAGE = REPO / "skills" / "shadow-frog-viewer" / "dream-lineage.py"
+
+
+def _narrow_env():
+    """Environment that forces a narrow (non-UTF-8) default codec everywhere."""
+    env = dict(os.environ)
+    env["PYTHONIOENCODING"] = "cp1252"  # narrow stdout/stderr codec
+    env["PYTHONUTF8"] = "0"             # ensure UTF-8 Mode isn't masking it
+    env["LC_ALL"] = "C"                 # narrow default file codec on POSIX
+    return env
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_shadow_viewer_invariants_under_narrow_codec():
+    """shadow-viewer prints a non-ASCII check mark; it must survive a pipe."""
+    r = subprocess.run(
+        [sys.executable, str(VIEWER), "--check-invariants",
+         "--shadow-dir", str(DEMO_SHADOW)],
+        capture_output=True, encoding="utf-8", env=_narrow_env(),
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    assert "\u2713 Invariants OK" in r.stdout  # the U+2713 check mark survived
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+def test_dream_lineage_writes_utf8_html_under_narrow_codec(tmp_path):
+    """dream-lineage embeds a frog emoji + box glyphs in the HTML it writes."""
+    out = tmp_path / "lineage.html"
+    r = subprocess.run(
+        [sys.executable, str(LINEAGE), "-o", str(out),
+         "--shadow-dir", str(DEMO_SHADOW)],
+        capture_output=True, encoding="utf-8", env=_narrow_env(),
+    )
+    assert r.returncode == 0, f"stderr:\n{r.stderr}"
+    # The U+1F438 frog must round-trip as UTF-8 bytes regardless of locale.
+    assert b"\xf0\x9f\x90\xb8" in out.read_bytes()

--- a/tests/test_cp1252_output_regression.py
+++ b/tests/test_cp1252_output_regression.py
@@ -18,14 +18,8 @@ UTF-8 pinned, both pass on every platform.
 import os
 import subprocess
 import sys
-from pathlib import Path
 
 import pytest
-
-REPO = Path(__file__).resolve().parent.parent
-DEMO_SHADOW = REPO / "examples" / "coupon-demo" / ".shadow"
-VIEWER = REPO / "skills" / "shadow-frog-viewer" / "shadow-viewer.py"
-LINEAGE = REPO / "skills" / "shadow-frog-viewer" / "dream-lineage.py"
 
 
 def _narrow_env():
@@ -39,27 +33,29 @@ def _narrow_env():
 
 @pytest.mark.slow
 @pytest.mark.integration
-def test_shadow_viewer_invariants_under_narrow_codec():
-    """shadow-viewer prints a non-ASCII check mark; it must survive a pipe."""
-    r = subprocess.run(
-        [sys.executable, str(VIEWER), "--check-invariants",
-         "--shadow-dir", str(DEMO_SHADOW)],
-        capture_output=True, encoding="utf-8", env=_narrow_env(),
-    )
-    assert r.returncode == 0, f"stderr:\n{r.stderr}"
-    assert "\u2713 Invariants OK" in r.stdout  # the U+2713 check mark survived
+class TestNarrowCodecOutput:
+    """Run the helpers under a forced narrow codec; non-ASCII output must survive."""
 
+    def test_shadow_viewer_invariants(self, repo_root, coupon_demo_src):
+        """shadow-viewer prints a non-ASCII check mark; it must survive a pipe."""
+        viewer = repo_root / "skills/shadow-frog-viewer/shadow-viewer.py"
+        r = subprocess.run(
+            [sys.executable, str(viewer), "--check-invariants",
+             "--shadow-dir", str(coupon_demo_src / ".shadow")],
+            capture_output=True, encoding="utf-8", env=_narrow_env(),
+        )
+        assert r.returncode == 0, f"stderr:\n{r.stderr}"
+        assert "\u2713 Invariants OK" in r.stdout  # the U+2713 check mark survived
 
-@pytest.mark.slow
-@pytest.mark.integration
-def test_dream_lineage_writes_utf8_html_under_narrow_codec(tmp_path):
-    """dream-lineage embeds a frog emoji + box glyphs in the HTML it writes."""
-    out = tmp_path / "lineage.html"
-    r = subprocess.run(
-        [sys.executable, str(LINEAGE), "-o", str(out),
-         "--shadow-dir", str(DEMO_SHADOW)],
-        capture_output=True, encoding="utf-8", env=_narrow_env(),
-    )
-    assert r.returncode == 0, f"stderr:\n{r.stderr}"
-    # The U+1F438 frog must round-trip as UTF-8 bytes regardless of locale.
-    assert b"\xf0\x9f\x90\xb8" in out.read_bytes()
+    def test_dream_lineage_writes_utf8_html(self, repo_root, coupon_demo_src, tmp_path):
+        """dream-lineage embeds a frog emoji + box glyphs in the HTML it writes."""
+        lineage = repo_root / "skills/shadow-frog-viewer/dream-lineage.py"
+        out = tmp_path / "lineage.html"
+        r = subprocess.run(
+            [sys.executable, str(lineage), "-o", str(out),
+             "--shadow-dir", str(coupon_demo_src / ".shadow")],
+            capture_output=True, encoding="utf-8", env=_narrow_env(),
+        )
+        assert r.returncode == 0, f"stderr:\n{r.stderr}"
+        # The U+1F438 frog must round-trip as UTF-8 bytes regardless of locale.
+        assert b"\xf0\x9f\x90\xb8" in out.read_bytes()


### PR DESCRIPTION
## Why

The Python CLI helpers emit and handle non-ASCII text (the `✓` status mark, em dashes, the `🐸` in generated HTML, box-drawing `─│└├`), but they never pin a text encoding. On Windows the default codec is `cp1252`, which cannot represent those characters, so under any non-TTY stdout (a shell pipe, CI, or pytest's capture) the helpers raise `UnicodeEncodeError` / `UnicodeDecodeError` and crash mid-output, or silently produce mojibake. Linux and macOS default to UTF-8, so the failure never appears there, which is why the existing CI is green while the tools are broken on Windows.

What this looks like on Windows today:

- `dream-validate` crashes the pre-commit hard gate while printing its summary.
- `shadow-viewer --check-invariants` dies writing the `✓ Invariants OK` line.
- `dream-lineage` fails writing its HTML report (it embeds `🐸` and box glyphs).

## What changed

Pin UTF-8 at the three text-I/O boundaries, in the affected helpers and their tests:

1. **stdout/stderr** — `reconfigure(encoding="utf-8")` at each entry point.
2. **files** — `encoding="utf-8"` on every text `open` / `read_text` / `write_text`.
3. **subprocess** — `encoding="utf-8"` on every `subprocess.run(text=True, ...)`.

| File | Change |
|---|---|
| `skills/shadow-frog-dream/dream-validate.py` | stdout guard; `encoding=` on the report/manifest reads and the git `diff`/`status` calls |
| `skills/shadow-frog-viewer/shadow-viewer.py` | stdout guard (it already encodes its file reads) |
| `skills/shadow-frog-viewer/dream-lineage.py` | `encoding=` on the HTML write and all six `.shadow/` reads |
| the three matching test modules | `encoding=` on every `read_text` / `write_text` / `subprocess` site |

## New cross-platform regression

`tests/test_cp1252_output_regression.py` forces the narrow-codec failure mode on **any** OS (`PYTHONIOENCODING=cp1252` for streams; `LC_ALL=C` + `PYTHONUTF8=0` for files), so the fix is verifiable on the current Linux CI even before a Windows CI job exists. Reverting the source fixes makes it fail with the exact `'charmap' codec can't encode '\U0001f438'` error.

## Verification

- 251 tests pass on Windows (the three helpers' suites plus the new regression).
- No behavior change on Linux: the encoding pins are no-ops where the default is already UTF-8.

## Scope and follow-ups

This is the first, focused slice of a broader cross-platform effort (#7). A **wider change to pin UTF-8 on all text I/O across the repo** is planned: an audit turned up many more `open` / `read_text` / `write_text` / `subprocess` call sites without an explicit encoding, and those will land in follow-up PRs (kept separate so each stays small and reviewable).

`shadow-init.py` is intentionally untouched here: it has no non-ASCII stdout and already encodes its writes. Its Windows failures are path-separator and file-permission issues, handled in a later change.

Part of #7
Closes #8

_Co-authored with Copilot 🤖_
