### PR TITLE
[Windows port] 1b/8: pin UTF-8 on all text I/O in stable helpers (Windows cp1252)

### DIFF
--- a/skills/shadow-frog-dream/dream-coverage.py
+++ b/skills/shadow-frog-dream/dream-coverage.py
@@ -96,7 +96,7 @@ def get_source_files(repo_root, scopes=None):
     """
     result = subprocess.run(
         ['git', 'ls-files', '-z'],
-        capture_output=True, text=True, cwd=repo_root
+        capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
     )
     files = []
     for f in result.stdout.split('\0'):
@@ -118,7 +118,7 @@ def _count_discoveries(shadow_path):
     """
     count = 0
     in_xref = False
-    with open(shadow_path) as sf:
+    with open(shadow_path, encoding="utf-8") as sf:
         for line in sf:
             stripped = line.rstrip('\n')
             if stripped.startswith('## ') or stripped.startswith('### '):
@@ -171,7 +171,7 @@ def compute_fan_in(repo_root, uncovered_files, max_files=200):
             result = subprocess.run(
                 ['git', 'grep', '-F', '-w', '-l', '--', base],
                 capture_output=True, text=True, cwd=repo_root,
-                timeout=10
+                timeout=10, encoding="utf-8"
             )
             count = len([l for l in result.stdout.strip().split('\n') if l]) if result.stdout.strip() else 0
             for f in files_for_base:
@@ -184,6 +184,9 @@ def compute_fan_in(repo_root, uncovered_files, max_files=200):
 
 
 def main():
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     parser = argparse.ArgumentParser(
         description="Dream coverage map — compute exploration coverage for task planning.",
         formatter_class=argparse.RawDescriptionHelpFormatter,

--- a/skills/shadow-frog-dream/dream-reconcile.py
+++ b/skills/shadow-frog-dream/dream-reconcile.py
@@ -151,7 +151,7 @@ def git(*args, cwd=None, check=True):
     """Run a git command and return stdout."""
     result = subprocess.run(
         ['git'] + list(args),
-        capture_output=True, text=True, cwd=cwd
+        capture_output=True, text=True, cwd=cwd, encoding="utf-8"
     )
     if check and result.returncode != 0:
         raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
@@ -162,7 +162,7 @@ def git_show(ref, path, cwd=None):
     """Read a file from a git ref. Returns None if not found."""
     result = subprocess.run(
         ['git', 'show', f'{ref}:{path}'],
-        capture_output=True, text=True, cwd=cwd
+        capture_output=True, text=True, cwd=cwd, encoding="utf-8"
     )
     if result.returncode != 0:
         return None
@@ -206,7 +206,7 @@ def _read_indexed_dream_ids(repo_root):
     existing = set()
     if not os.path.isfile(index_path):
         return existing
-    with open(index_path) as f:
+    with open(index_path, encoding="utf-8") as f:
         for line in f:
             if line.startswith('|') and not line.startswith('| dream_id') and not line.startswith('|---'):
                 parts = [p.strip() for p in line.split('|')]
@@ -221,7 +221,7 @@ def _read_indexed_branches(repo_root):
     rows = []
     if not os.path.isfile(index_path):
         return rows
-    with open(index_path) as f:
+    with open(index_path, encoding="utf-8") as f:
         for line in f:
             if line.startswith('|') and not line.startswith('| dream_id') and not line.startswith('|---'):
                 parts = [p.strip() for p in line.split('|')]
@@ -463,7 +463,7 @@ def merge_discovery_into_file(shadow_path, anchor_symbol, discovery, dream_id):
             '## Cross-References\n', '\n', '_No cross-cutting discoveries yet._\n',
         ]
     else:
-        with open(shadow_path) as f:
+        with open(shadow_path, encoding="utf-8") as f:
             lines = f.readlines()
         lines = _ensure_cross_references_section(lines)
 
@@ -497,7 +497,7 @@ def merge_discovery_into_file(shadow_path, anchor_symbol, discovery, dream_id):
             if not changed:
                 return False
             lines[meta_idx] = _format_meta_line(m_status, m_source, m_labels)
-            with open(shadow_path, 'w') as f:
+            with open(shadow_path, 'w', encoding="utf-8") as f:
                 f.writelines(lines)
             return True
 
@@ -525,7 +525,7 @@ def merge_discovery_into_file(shadow_path, anchor_symbol, discovery, dream_id):
         new_section = ['\n', f'## `{anchor_symbol}`\n', '\n'] + lines_to_add
         lines[insert_at:insert_at] = new_section
 
-    with open(shadow_path, 'w') as f:
+    with open(shadow_path, 'w', encoding="utf-8") as f:
         f.writelines(lines)
 
     return True
@@ -548,7 +548,7 @@ def add_cross_reference_backpointer(repo_root, file_part, slug, title, dream_id)
     backpointer = f'- [{title}]({prefix}_cross/{slug}.md) (dream: {dream_id})'
 
     if os.path.isfile(shadow_path):
-        with open(shadow_path) as f:
+        with open(shadow_path, encoding="utf-8") as f:
             lines = f.readlines()
     else:
         # Create a minimal shadow file with the canonical header + footer if
@@ -570,7 +570,7 @@ def add_cross_reference_backpointer(repo_root, file_part, slug, title, dream_id)
     # legitimate back-pointer add.
     link_marker = f']({prefix}_cross/{slug}.md)'
     if any(link_marker in line for line in lines):
-        with open(shadow_path, 'w') as f:
+        with open(shadow_path, 'w', encoding="utf-8") as f:
             f.writelines(lines)
         return False
 
@@ -599,7 +599,7 @@ def add_cross_reference_backpointer(repo_root, file_part, slug, title, dream_id)
             insert_at -= 1
         lines[insert_at:insert_at] = [f'{backpointer}\n']
 
-    with open(shadow_path, 'w') as f:
+    with open(shadow_path, 'w', encoding="utf-8") as f:
         f.writelines(lines)
     return True
 
@@ -613,7 +613,7 @@ def _merge_refs_into_cross_file(cross_path, new_refs):
     bidirectional-reference invariant breaks. Returns True if modified.
     """
     try:
-        with open(cross_path) as f:
+        with open(cross_path, encoding="utf-8") as f:
             content = f.read()
     except OSError:
         return False
@@ -638,7 +638,7 @@ def _merge_refs_into_cross_file(cross_path, new_refs):
     if not to_add:
         return False
     lines[block_end:block_end] = [f'- `{r}`' for r in to_add]
-    with open(cross_path, 'w') as f:
+    with open(cross_path, 'w', encoding="utf-8") as f:
         f.write('\n'.join(lines))
     return True
 
@@ -709,7 +709,7 @@ def merge_discoveries(repo_root, manifests, dry_run=False):
                     f"_({cross.get('status', 'verified')}, "
                     f"source: {cross.get('source', 'exploration')})_\n"
                 )
-                with open(cross_path, 'w') as f:
+                with open(cross_path, 'w', encoding="utf-8") as f:
                     f.write(content)
                 merged_count += 1
             else:
@@ -772,16 +772,16 @@ def mirror_reports(repo_root, manifests, dry_run=False):
                     # and patch below are still mirrored unconditionally so a
                     # single bad frontmatter line never discards valid
                     # artifacts (discoveries are read from the manifest).
-                    with open(os.path.join(dream_dir, 'report.md'), 'w') as f:
+                    with open(os.path.join(dream_dir, 'report.md'), 'w', encoding="utf-8") as f:
                         f.write(f"# Corrupted Report\n\nContained content from {report_did}.\n"
                                 f"Original on branch: {branch}\n")
 
             if not report_corrupt:
-                with open(os.path.join(dream_dir, 'report.md'), 'w') as f:
+                with open(os.path.join(dream_dir, 'report.md'), 'w', encoding="utf-8") as f:
                     f.write(report)
 
         # Mirror manifest
-        with open(os.path.join(dream_dir, 'manifest.json'), 'w') as f:
+        with open(os.path.join(dream_dir, 'manifest.json'), 'w', encoding="utf-8") as f:
             json.dump(manifest, f, indent=2)
 
         # Mirror patch
@@ -796,7 +796,7 @@ def mirror_reports(repo_root, manifests, dry_run=False):
         # write only when truly absent.
         patch = git_show(f'origin/{branch}', f'.shadow/_dreams/{dream_id}/patch.diff', cwd=repo_root)
         if patch is not None:
-            with open(os.path.join(dream_dir, 'patch.diff'), 'w') as f:
+            with open(os.path.join(dream_dir, 'patch.diff'), 'w', encoding="utf-8") as f:
                 f.write(patch)
 
         mirrored += 1
@@ -836,12 +836,12 @@ def update_index(repo_root, manifests, dry_run=False):
     # stays clean — dry-run must not mutate disk).
     if not os.path.isfile(index_path):
         os.makedirs(os.path.dirname(index_path), exist_ok=True)
-        with open(index_path, 'w') as f:
+        with open(index_path, 'w', encoding="utf-8") as f:
             f.write('# Dream Experiment Archive\n\n'
                     '| dream_id | category | verdict | title | branch | parent | tip_commit |\n'
                     '|----------|----------|---------|-------|--------|--------|------------|\n')
 
-    with open(index_path, 'a') as f:
+    with open(index_path, 'a', encoding="utf-8") as f:
         for branch, dream_id, manifest in manifests:
             tip = _resolve_tip_commit(repo_root, branch)
             cat = re.sub(r'\s*\(.*\)\s*$', '', manifest.get('category', 'unknown').lower().strip())
@@ -878,7 +878,7 @@ def _count_discoveries(shadow_path):
     if not os.path.isfile(shadow_path):
         return 0
     count = 0
-    with open(shadow_path) as sf:
+    with open(shadow_path, encoding="utf-8") as sf:
         in_xref = False
         for line in sf:
             stripped = line.rstrip()
@@ -913,7 +913,7 @@ def update_state(repo_root, manifests, dry_run=False):
             'dream_cycles_completed': 0,
         }
     else:
-        with open(state_path) as f:
+        with open(state_path, encoding="utf-8") as f:
             state = json.load(f)
 
     if dry_run:
@@ -944,7 +944,7 @@ def update_state(repo_root, manifests, dry_run=False):
                 continue
 
             total_files += 1
-            with open(filepath) as f:
+            with open(filepath, encoding="utf-8") as f:
                 # `## Cross-References` and `## File-Level` are structural
                 # sections, not symbols. Bullets inside `## Cross-References`
                 # are back-pointer links to `_cross/*.md`, not discoveries.
@@ -978,7 +978,7 @@ def update_state(repo_root, manifests, dry_run=False):
     except RuntimeError:
         pass
 
-    with open(state_path, 'w') as f:
+    with open(state_path, 'w', encoding="utf-8") as f:
         json.dump(state, f, indent=2)
 
 
@@ -1005,7 +1005,7 @@ def _shadow_symbol_names(shadow_path):
     names = []
     if not os.path.isfile(shadow_path):
         return names
-    with open(shadow_path) as sf:
+    with open(shadow_path, encoding="utf-8") as sf:
         for line in sf:
             stripped = line.rstrip()
             if not stripped.startswith('## '):
@@ -1032,7 +1032,7 @@ def _shadow_language(shadow_path):
     """
     if not os.path.isfile(shadow_path):
         return 'Unknown'
-    with open(shadow_path) as sf:
+    with open(shadow_path, encoding="utf-8") as sf:
         for i, line in enumerate(sf):
             if i > 10:
                 break
@@ -1074,7 +1074,7 @@ def rebuild_top_index(repo_root, dry_run=False):
     original_init_date = None
     if os.path.isfile(index_path):
         try:
-            with open(index_path) as f:
+            with open(index_path, encoding="utf-8") as f:
                 for line in f:
                     m = re.match(
                         r'>\s*(?:Initially g|G)enerated by shadow-frog-init on (\S+)',
@@ -1138,7 +1138,7 @@ def rebuild_top_index(repo_root, dry_run=False):
     state_path = os.path.join(shadow_dir, '_meta', 'state.json')
     if os.path.isfile(state_path):
         try:
-            with open(state_path) as f:
+            with open(state_path, encoding="utf-8") as f:
                 dream_cycles = int(json.load(f).get('dream_cycles_completed', 0) or 0)
         except (json.JSONDecodeError, OSError, ValueError, TypeError):
             dream_cycles = 0
@@ -1173,7 +1173,7 @@ def rebuild_top_index(repo_root, dry_run=False):
     out.append('')
 
     try:
-        with open(index_path, 'w') as f:
+        with open(index_path, 'w', encoding="utf-8") as f:
             f.write('\n'.join(out))
     except OSError as e:
         print(f"  ⚠️  Could not write _index.md: {e}")
@@ -1250,7 +1250,7 @@ def cleanup_branches(repo_root, manifests, dream_ns, dry_run=False):
         # signal that reconciliation output has not been committed + pushed.
         shadow_status = subprocess.run(
             ['git', 'status', '--porcelain=v1', '--', '.shadow/'],
-            capture_output=True, text=True, cwd=repo_root
+            capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
         )
         if shadow_status.stdout.strip():
             print(f"  ❌ Refusing cleanup: .shadow/ has uncommitted changes.", file=sys.stderr)
@@ -1272,7 +1272,7 @@ def cleanup_branches(repo_root, manifests, dream_ns, dry_run=False):
         ancestor_check = subprocess.run(
             ['git', 'merge-base', '--is-ancestor',
              head_sha, f'origin/{default_branch}'],
-            capture_output=True, text=True, cwd=repo_root
+            capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
         )
         if ancestor_check.returncode != 0:
             print(f"  ❌ Refusing cleanup: HEAD ({head_sha[:7]}) is NOT an", file=sys.stderr)
@@ -1358,7 +1358,7 @@ def cleanup_branches(repo_root, manifests, dream_ns, dry_run=False):
         # Delete remote first (network op that can fail)
         result = subprocess.run(
             ['git', 'push', 'origin', '--delete', branch],
-            capture_output=True, text=True, cwd=repo_root
+            capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
         )
         if result.returncode == 0:
             print(f"  🗑  Deleted remote: {branch}")
@@ -1370,14 +1370,14 @@ def cleanup_branches(repo_root, manifests, dream_ns, dry_run=False):
         # Delete local
         result = subprocess.run(
             ['git', 'branch', '-D', branch],
-            capture_output=True, text=True, cwd=repo_root
+            capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
         )
         if result.returncode == 0:
             print(f"  🗑  Deleted local: {branch}")
         # Also delete the remote-tracking ref
         subprocess.run(
             ['git', 'branch', '-dr', f'origin/{branch}'],
-            capture_output=True, text=True, cwd=repo_root
+            capture_output=True, text=True, cwd=repo_root, encoding="utf-8"
         )
 
         # Best-effort worktree GC — the directory at
@@ -1435,6 +1435,7 @@ def _registered_worktree_branch(repo_root, candidate_path):
         result = subprocess.run(
             ['git', 'worktree', 'list', '--porcelain'],
             capture_output=True, text=True, cwd=repo_root, timeout=10,
+            encoding="utf-8",
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -1528,6 +1529,7 @@ def _gc_worktree_after_merge(repo_root, dream_ns, dream_id, deleted_branch=None)
         result = subprocess.run(
             ['git', 'worktree', 'remove', str(resolved), '--force'],
             capture_output=True, text=True, cwd=repo_root,
+            encoding="utf-8",
         )
         if result.returncode == 0:
             worktree_removed = True
@@ -1547,6 +1549,7 @@ def _gc_worktree_after_merge(repo_root, dream_ns, dream_id, deleted_branch=None)
         subprocess.run(
             ['git', 'worktree', 'prune'],
             capture_output=True, text=True, cwd=repo_root,
+            encoding="utf-8",
         )
     except Exception as exc:  # noqa: BLE001 — GC must never crash cleanup.
         print(f"  ⚠️  Worktree GC raised for {dream_id}: {exc}")
@@ -1555,6 +1558,9 @@ def _gc_worktree_after_merge(repo_root, dream_ns, dream_id, deleted_branch=None)
 # --- Main orchestration ---
 
 def main():
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     # Parse arguments
     repo_root = None
     dry_run = False
@@ -1591,7 +1597,7 @@ def main():
     if not repo_root:
         repo_root = subprocess.run(
             ['git', 'rev-parse', '--show-toplevel'],
-            capture_output=True, text=True
+            capture_output=True, text=True, encoding="utf-8"
         ).stdout.strip()
 
     if not repo_root or not os.path.isdir(repo_root):
@@ -1604,13 +1610,13 @@ def main():
         task_info = os.path.join(repo_root, 'TASK_INFO.json')
         if os.path.isfile(task_info):
             try:
-                dream_ns = json.load(open(task_info)).get('dream_namespace', '')
+                dream_ns = json.load(open(task_info, encoding="utf-8")).get('dream_namespace', '')
             except (json.JSONDecodeError, OSError):
                 pass
     if not dream_ns:
         env_file = os.path.join(repo_root, '.env')
         if os.path.isfile(env_file):
-            with open(env_file) as f:
+            with open(env_file, encoding="utf-8") as f:
                 for line in f:
                     if line.startswith('DREAM_NAMESPACE='):
                         dream_ns = line.split('=', 1)[1].strip()
@@ -1643,7 +1649,7 @@ def main():
             )
             if os.path.isfile(local_manifest):
                 try:
-                    with open(local_manifest) as f:
+                    with open(local_manifest, encoding="utf-8") as f:
                         m = json.load(f)
                     manifests.append((branch, dream_id, m))
                 except (json.JSONDecodeError, OSError):
@@ -1682,7 +1688,7 @@ def main():
                 m = {}
                 if os.path.isfile(local_manifest):
                     try:
-                        with open(local_manifest) as f:
+                        with open(local_manifest, encoding="utf-8") as f:
                             m = json.load(f)
                     except (json.JSONDecodeError, OSError):
                         pass

--- a/skills/shadow-frog-init/shadow-init.py
+++ b/skills/shadow-frog-init/shadow-init.py
@@ -65,6 +65,7 @@ def run_git(args, cwd=None):
         result = subprocess.run(
             ["git"] + args,
             capture_output=True, text=True, timeout=30, cwd=cwd, env=env,
+            encoding="utf-8",
         )
         if result.returncode != 0:
             warn(f"git {' '.join(args)} failed: {result.stderr.strip()}")
@@ -98,7 +99,7 @@ def find_repo_root():
         # pointing to a non-existent or inaccessible gitdir path
         git_path = Path(".git")
         if git_path.is_file():
-            gitdir_line = git_path.read_text().strip()
+            gitdir_line = git_path.read_text(encoding="utf-8").strip()
             warn(f"git rev-parse --show-toplevel failed. "
                  f".git is a file (worktree): {gitdir_line}. "
                  "The gitdir path may be inaccessible (e.g., running inside Docker "
@@ -1449,6 +1450,9 @@ def init_shadow(repo_root, reset=False, dry_run=False):
 # ---------------------------------------------------------------------------
 
 def main():
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     parser = argparse.ArgumentParser(
         description="Initialize a .shadow/ knowledge base for any codebase.",
         prog="shadow-init.py",

--- a/skills/shadow-frog-meditate/meditate-repair.py
+++ b/skills/shadow-frog-meditate/meditate-repair.py
@@ -74,7 +74,7 @@ def detect_corrupted(dreams_dir: str) -> set[str]:
         report = os.path.join(dpath, 'report.md')
         if not os.path.exists(report):
             continue
-        with open(report) as rf:
+        with open(report, encoding="utf-8") as rf:
             rcontent = rf.read()
         fm_match = re.search(r'dream_id:\s*(\S+)', rcontent)
         body_match = re.search(r'\*\*Dream ID\*\*:\s*(\S+)', rcontent)
@@ -97,7 +97,7 @@ def lookup_verdict(dream_dir: str, content: str) -> str:
     manifest = os.path.join(dream_dir, 'manifest.json')
     if os.path.exists(manifest):
         try:
-            with open(manifest) as mf:
+            with open(manifest, encoding="utf-8") as mf:
                 mdata = json.load(mf)
             v = (mdata.get('verdict') or '').lower().strip()
             if v and v != 'unknown':
@@ -120,7 +120,7 @@ def repair_row(parts: list[str], dreams_dir: str) -> tuple[list[str], bool] | No
     report = os.path.join(dream_dir, 'report.md')
     if not os.path.exists(report):
         return None
-    with open(report) as rf:
+    with open(report, encoding="utf-8") as rf:
         content = rf.read()
 
     original = list(parts)
@@ -204,7 +204,7 @@ def repair_parent(
     parent_branch_raw: str | None = None
     if os.path.exists(manifest_path):
         try:
-            with open(manifest_path) as mf:
+            with open(manifest_path, encoding="utf-8") as mf:
                 mdata = json.load(mf)
             pb = mdata.get('parent_branch', '').strip()
             if pb and pb != 'main':
@@ -216,7 +216,7 @@ def repair_parent(
     if parent_branch_raw is None:
         report_path = os.path.join(dream_dir, 'report.md')
         if os.path.exists(report_path):
-            with open(report_path) as rf:
+            with open(report_path, encoding="utf-8") as rf:
                 rcontent = rf.read()
             fm_match = re.search(r'parent_branch:\s*["\']?([^"\'\n]+)', rcontent)
             if fm_match:
@@ -298,6 +298,9 @@ def repair_parent(
 
 
 def main() -> int:
+    for _stream in (sys.stdout, sys.stderr):
+        if hasattr(_stream, "reconfigure"):
+            _stream.reconfigure(encoding="utf-8")
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument('--shadow-dir', default='.shadow',
                     help='Shadow root (default: .shadow)')
@@ -309,11 +312,11 @@ def main() -> int:
         print(f'ERROR: {index_path} not found', file=sys.stderr)
         return 1
 
-    with open(index_path) as f:
+    with open(index_path, encoding="utf-8") as f:
         lines = f.readlines()
 
     backup = index_path + '.bak'
-    with open(backup, 'w') as bf:
+    with open(backup, 'w', encoding="utf-8") as bf:
         bf.writelines(lines)
 
     corrupted = detect_corrupted(dreams_dir)
@@ -357,7 +360,7 @@ def main() -> int:
             lines[i] = '| ' + ' | '.join(new_parts[1:-1]) + ' |\n'
             repaired += 1
 
-    with open(index_path, 'w') as f:
+    with open(index_path, 'w', encoding="utf-8") as f:
         f.writelines(lines)
 
     print(

--- a/tests/skills/shadow_frog_dream/test_dream_coverage.py
+++ b/tests/skills/shadow_frog_dream/test_dream_coverage.py
@@ -32,7 +32,7 @@ def _seed_tree(repo: Path, files: dict[str, str]):
     for rel, content in files.items():
         path = repo / rel
         path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(content)
+        path.write_text(content, encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=repo, env=env, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "seed"], cwd=repo, env=env, check=True)
 
@@ -151,7 +151,7 @@ def test_count_discoveries_excludes_cross_references(dream_coverage, tmp_path):
         "\n"
         "## Cross-References\n\n"
         "- [bp one](_cross/a.md)\n"
-        "- [bp two](_cross/b.md)\n"
+        "- [bp two](_cross/b.md)\n", encoding="utf-8"
     )
     assert dream_coverage._count_discoveries(str(shadow)) == 4
 
@@ -159,7 +159,7 @@ def test_count_discoveries_excludes_cross_references(dream_coverage, tmp_path):
 def test_count_discoveries_handles_lowercase_xref(dream_coverage, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
-        "## `foo`\n\n- real\n\n## cross-references\n\n- [bp](_cross/x.md)\n"
+        "## `foo`\n\n- real\n\n## cross-references\n\n- [bp](_cross/x.md)\n", encoding="utf-8"
     )
     assert dream_coverage._count_discoveries(str(shadow)) == 1
 
@@ -187,10 +187,10 @@ def test_check_coverage_classifies_files(dream_coverage, tmp_git_repo):
     })
     (tmp_git_repo / ".shadow").mkdir()
     (tmp_git_repo / ".shadow" / "a.py.md").write_text(
-        "## `a`\n\n- one\n- two\n"
+        "## `a`\n\n- one\n- two\n", encoding="utf-8"
     )
     (tmp_git_repo / ".shadow" / "b.py.md").write_text(
-        "## `b`\n\n_No discoveries yet._\n"
+        "## `b`\n\n_No discoveries yet._\n", encoding="utf-8"
     )
     # c.py: no shadow at all.
 
@@ -209,7 +209,7 @@ def test_check_coverage_saturated_threshold(dream_coverage, tmp_git_repo):
     _seed_tree(tmp_git_repo, {"big.py": "x\n"})
     (tmp_git_repo / ".shadow").mkdir()
     (tmp_git_repo / ".shadow" / "big.py.md").write_text(
-        "## `big`\n\n" + "\n".join(f"- discovery {i}" for i in range(8)) + "\n"
+        "## `big`\n\n" + "\n".join(f"- discovery {i}" for i in range(8)) + "\n", encoding="utf-8"
     )
     files = dream_coverage.get_source_files(str(tmp_git_repo))
     covered, uncovered, saturated = dream_coverage.check_coverage(
@@ -288,6 +288,7 @@ def test_cli_help_exits_zero():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--help"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "Dream coverage" in result.stdout or "coverage" in result.stdout.lower()
@@ -299,6 +300,7 @@ def test_cli_runs_against_coupon_demo(coupon_demo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(coupon_demo)],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "EXPLORATION COVERAGE MAP" in result.stdout
@@ -314,6 +316,7 @@ def test_cli_scope_with_no_matches_exits_nonzero(coupon_demo):
         [sys.executable, str(SCRIPT), str(coupon_demo),
          "--scope", "no-such-prefix/"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 2
     assert "No source files matched" in result.stdout
@@ -326,6 +329,7 @@ def test_cli_scope_filters_to_subset(coupon_demo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(coupon_demo), "--scope", "cart.py"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Total source files: 1" in result.stdout

--- a/tests/skills/shadow_frog_dream/test_dream_reconcile.py
+++ b/tests/skills/shadow_frog_dream/test_dream_reconcile.py
@@ -41,7 +41,7 @@ def _git_env(home: Path) -> dict:
 
 def _run(cmd, cwd, env=None, check=True):
     return subprocess.run(
-        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=check
+        cmd, cwd=cwd, env=env, capture_output=True, text=True, check=check, encoding="utf-8"
     )
 
 
@@ -52,7 +52,7 @@ def _git(*args, cwd, env, check=True):
 def _seed_repo(repo: Path):
     """Seed an empty initialized git repo with one commit and a bare origin."""
     env = _git_env(repo)
-    (repo / "README.md").write_text("# test\n")
+    (repo / "README.md").write_text("# test\n", encoding="utf-8")
     _git("add", "-A", cwd=repo, env=env)
     _git("commit", "-q", "-m", "init", cwd=repo, env=env)
     return env
@@ -93,17 +93,17 @@ def make_dream_branch(
 
     dream_dir = repo / ".shadow" / "_dreams" / dream_id
     dream_dir.mkdir(parents=True, exist_ok=True)
-    (dream_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    (dream_dir / "manifest.json").write_text(json.dumps(manifest, indent=2), encoding="utf-8")
     if report is not None:
-        (dream_dir / "report.md").write_text(report)
+        (dream_dir / "report.md").write_text(report, encoding="utf-8")
     if patch is not None:
-        (dream_dir / "patch.diff").write_text(patch)
+        (dream_dir / "patch.diff").write_text(patch, encoding="utf-8")
 
     if extra_files:
         for rel, content in extra_files.items():
             target = repo / rel
             target.parent.mkdir(parents=True, exist_ok=True)
-            target.write_text(content)
+            target.write_text(content, encoding="utf-8")
 
     _git("add", "-A", cwd=repo, env=env)
     _git("commit", "-q", "-m", f"dream: {dream_id}", cwd=repo, env=env)
@@ -259,7 +259,7 @@ def test_add_cross_reference_backpointer_bootstraps_missing_shadow(dream_reconci
 
     shadow = repo / ".shadow" / "src" / "foo.py.md"
     assert shadow.is_file()
-    text = shadow.read_text()
+    text = shadow.read_text(encoding="utf-8")
     assert "## File-Level" in text
     assert "## Cross-References" in text
     # depth=1 for src/foo.py → prefix "../"
@@ -281,7 +281,7 @@ def test_add_cross_reference_backpointer_is_idempotent(dream_reconcile, tmp_path
     assert written2 is False
 
     shadow = repo / ".shadow" / "foo.py.md"
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert body.count("[Title X](_cross/slug-x.md)") == 1
 
 
@@ -300,7 +300,7 @@ def test_add_cross_reference_backpointer_false_positive_substring(dream_reconcil
         "\n"
         "## Cross-References\n"
         "\n"
-        "_No cross-cutting discoveries yet._\n"
+        "_No cross-cutting discoveries yet._\n", encoding="utf-8"
     )
 
     written = dream_reconcile.add_cross_reference_backpointer(
@@ -308,7 +308,7 @@ def test_add_cross_reference_backpointer_false_positive_substring(dream_reconcil
     )
     assert written is True
 
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "[Foo Title](_cross/foo.md)" in body
     # Discovery line preserved.
     assert "talks about `_cross/foo.md`" in body
@@ -330,7 +330,7 @@ def test_add_cross_reference_backpointer_depth_math(
     shadow = repo / ".shadow" / (file_part + ".md")
     assert shadow.is_file()
     expected = f"[T]({expected_prefix}_cross/slug.md)"
-    assert expected in shadow.read_text()
+    assert expected in shadow.read_text(encoding="utf-8")
 
 
 def test_add_cross_reference_backpointer_replaces_placeholder(
@@ -340,12 +340,12 @@ def test_add_cross_reference_backpointer_replaces_placeholder(
     (repo / ".shadow").mkdir()
     shadow = repo / ".shadow" / "foo.py.md"
     shadow.write_text(
-        "## `foo`\n\n- d\n\n## Cross-References\n\n_No cross-cutting discoveries yet._\n"
+        "## `foo`\n\n- d\n\n## Cross-References\n\n_No cross-cutting discoveries yet._\n", encoding="utf-8"
     )
     dream_reconcile.add_cross_reference_backpointer(
         str(repo), "foo.py", "slug-y", "Y", "20260101-000000Z-q"
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "_No cross-cutting discoveries yet._" not in body
     assert "[Y](_cross/slug-y.md)" in body
 
@@ -365,7 +365,7 @@ def test_merge_discovery_creates_new_shadow(dream_reconcile, tmp_path):
     )
     assert written is True
     assert shadow.is_file()
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "## `do_thing`" in body
     assert "- Returns None on empty input." in body
     assert "_(verified, source: exploration)_" in body
@@ -376,7 +376,7 @@ def test_merge_discovery_creates_new_shadow(dream_reconcile, tmp_path):
 def test_merge_discovery_replaces_no_discoveries_placeholder(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
-        "## `foo`\n\n_No discoveries yet._\n\n## Cross-References\n\n_No cross-cutting discoveries yet._\n"
+        "## `foo`\n\n_No discoveries yet._\n\n## Cross-References\n\n_No cross-cutting discoveries yet._\n", encoding="utf-8"
     )
     dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -384,7 +384,7 @@ def test_merge_discovery_replaces_no_discoveries_placeholder(dream_reconcile, tm
          "source": "exploration"},
         "20260101-000000Z-x",
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "_No discoveries yet._" not in body
     assert "- Actual discovery." in body
 
@@ -393,7 +393,7 @@ def test_merge_discovery_appends_after_existing_bullets(dream_reconcile, tmp_pat
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- existing discovery\n  _(verified, source: exploration)_\n\n"
-        "## Cross-References\n\n_No cross-cutting discoveries yet._\n"
+        "## Cross-References\n\n_No cross-cutting discoveries yet._\n", encoding="utf-8"
     )
     dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -401,7 +401,7 @@ def test_merge_discovery_appends_after_existing_bullets(dream_reconcile, tmp_pat
          "source": "exploration"},
         "20260101-000000Z-x",
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "- existing discovery" in body
     assert "- Another discovery." in body
     # Discovery order preserved.
@@ -412,7 +412,7 @@ def test_merge_discovery_skips_duplicate(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- already here\n  _(verified, source: exploration)_\n\n"
-        "## Cross-References\n\n_No cross-cutting discoveries yet._\n"
+        "## Cross-References\n\n_No cross-cutting discoveries yet._\n", encoding="utf-8"
     )
     written = dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -444,7 +444,7 @@ def test_merge_discovery_unions_labels_on_exact_match(dream_reconcile, tmp_path)
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- claim text here\n  _(verified, source: exploration, labels: [bug])_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     written = dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -453,7 +453,7 @@ def test_merge_discovery_unions_labels_on_exact_match(dream_reconcile, tmp_path)
         "20260101-000000Z-x",
     )
     assert written is True
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     # Single merged discovery line (no duplicate appended).
     assert body.count("- claim text here") == 1
     assert "labels: [bug, security]" in body
@@ -463,7 +463,7 @@ def test_merge_discovery_upgrades_source_trust(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- some claim\n  _(verified, source: exploration)_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     written = dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -471,7 +471,7 @@ def test_merge_discovery_upgrades_source_trust(dream_reconcile, tmp_path):
         "20260101-000000Z-x",
     )
     assert written is True
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "source: user" in body
     assert "source: exploration" not in body
 
@@ -480,7 +480,7 @@ def test_merge_discovery_upgrades_uncertain_to_verified(dream_reconcile, tmp_pat
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- a claim\n  _(uncertain, source: exploration)_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     written = dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -488,7 +488,7 @@ def test_merge_discovery_upgrades_uncertain_to_verified(dream_reconcile, tmp_pat
         "20260101-000000Z-x",
     )
     assert written is True
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "_(verified, source: exploration)_" in body
 
 
@@ -496,7 +496,7 @@ def test_merge_discovery_never_downgrades_verified(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- a claim\n  _(verified, source: exploration)_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     written = dream_reconcile.merge_discovery_into_file(
         str(shadow), "foo",
@@ -505,14 +505,14 @@ def test_merge_discovery_never_downgrades_verified(dream_reconcile, tmp_path):
     )
     # Nothing to upgrade → no write.
     assert written is False
-    assert "_(verified, source: exploration)_" in shadow.read_text()
+    assert "_(verified, source: exploration)_" in shadow.read_text(encoding="utf-8")
 
 
 def test_merge_discovery_never_touches_refuted(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- a claim\n  _(refuted, source: exploration)_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     # New says verified — but refuted is a deliberate signal; status must hold.
     written = dream_reconcile.merge_discovery_into_file(
@@ -521,7 +521,7 @@ def test_merge_discovery_never_touches_refuted(dream_reconcile, tmp_path):
          "labels": ["bug"]},
         "20260101-000000Z-x",
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     # Status stays refuted; labels may still union.
     assert "refuted" in body
     assert "verified" not in body
@@ -535,7 +535,7 @@ def test_merge_discovery_fuzzy_match_still_skips(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         f"## `foo`\n\n{existing}\n  _(uncertain, source: exploration)_\n"
-        + _xref_footer()
+        + _xref_footer(), encoding="utf-8"
     )
     # Same words minus one — high overlap but not exact.
     new_text = ("the function returns none when the input list is "
@@ -547,7 +547,7 @@ def test_merge_discovery_fuzzy_match_still_skips(dream_reconcile, tmp_path):
     )
     # Treated as fuzzy duplicate → skipped, metadata untouched.
     assert written is False
-    assert "_(uncertain, source: exploration)_" in shadow.read_text()
+    assert "_(uncertain, source: exploration)_" in shadow.read_text(encoding="utf-8")
 
 
 class TestMetaMergeHelpers:
@@ -595,7 +595,7 @@ def test_merge_discovery_with_also_involves_and_labels(dream_reconcile, tmp_path
         },
         "20260101-000000Z-x",
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "labels: [bug, security]" in body
     assert "Also involves: `other.py::thing`, `more.py::stuff`" in body
 
@@ -617,7 +617,7 @@ INDEX_FIXTURE = """# Dream Experiments
 def _write_index(repo: Path, content: str = INDEX_FIXTURE):
     idx = repo / ".shadow" / "_dreams" / "_index.md"
     idx.parent.mkdir(parents=True, exist_ok=True)
-    idx.write_text(content)
+    idx.write_text(content, encoding="utf-8")
 
 
 def test_read_indexed_dream_ids_parses_table(dream_reconcile, tmp_path):
@@ -649,9 +649,9 @@ def test_read_indexed_branches_parses_table(dream_reconcile, tmp_path):
 def _seed_dream_artifacts(repo: Path, dream_id: str):
     d = repo / ".shadow" / "_dreams" / dream_id
     d.mkdir(parents=True, exist_ok=True)
-    (d / "report.md").write_text(f"# {dream_id}\n")
-    (d / "manifest.json").write_text("{}")
-    (d / "patch.diff").write_text("diff\n")
+    (d / "report.md").write_text(f"# {dream_id}\n", encoding="utf-8")
+    (d / "manifest.json").write_text("{}", encoding="utf-8")
+    (d / "patch.diff").write_text("diff\n", encoding="utf-8")
 
 
 def test_verify_reconciliation_passes_for_indexed_dream(dream_reconcile, tmp_path):
@@ -688,7 +688,7 @@ def test_verify_reconciliation_reports_missing_artifacts(dream_reconcile, tmp_pa
     # Only create report.md — manifest.json and patch.diff missing.
     d = tmp_path / ".shadow" / "_dreams" / dream_id
     d.mkdir(parents=True, exist_ok=True)
-    (d / "report.md").write_text("# r\n")
+    (d / "report.md").write_text("# r\n", encoding="utf-8")
     manifests = [(f"dream/p/{dream_id}", dream_id, {})]
     failures = dream_reconcile.verify_reconciliation(str(tmp_path), manifests)
     assert any("manifest.json" in f for f in failures)
@@ -853,7 +853,7 @@ def test_count_discoveries_excludes_cross_references_section(dream_reconcile, tm
         "\n"
         "## Cross-References\n\n"
         "- [back-pointer one](_cross/a.md)\n"
-        "- [back-pointer two](_cross/b.md)\n"
+        "- [back-pointer two](_cross/b.md)\n", encoding="utf-8"
     )
     assert dream_reconcile._count_discoveries(str(shadow)) == 5
 
@@ -863,7 +863,7 @@ def test_count_discoveries_case_insensitive_xref_heading(dream_reconcile, tmp_pa
     shadow = tmp_path / "foo.md"
     shadow.write_text(
         "## `foo`\n\n- real discovery\n\n"
-        "## cross-references\n\n- [bp](_cross/a.md)\n"
+        "## cross-references\n\n- [bp](_cross/a.md)\n", encoding="utf-8"
     )
     assert dream_reconcile._count_discoveries(str(shadow)) == 1
 
@@ -894,7 +894,7 @@ def test_shadow_symbol_names_extracts_top_level_only(dream_reconcile, tmp_path):
         "### `bar.method`\n\n- nested d (not counted)\n\n"
         "## `class Baz`\n\n- d\n\n"
         "## `interface IQux`\n\n- d\n\n"
-        "## Cross-References\n\n"
+        "## Cross-References\n\n", encoding="utf-8"
     )
     names = dream_reconcile._shadow_symbol_names(str(shadow))
     assert names == ["bar", "Baz", "IQux"]
@@ -909,14 +909,14 @@ def test_shadow_language_reads_header(dream_reconcile, tmp_path):
     shadow.write_text(
         "# Shadow: foo.py\n\n"
         "**Language**: Python | **Lines**: 28 | **Last modified**: 2026-04-20\n\n"
-        "## `foo`\n"
+        "## `foo`\n", encoding="utf-8"
     )
     assert dream_reconcile._shadow_language(str(shadow)) == "Python"
 
 
 def test_shadow_language_missing_header_returns_unknown(dream_reconcile, tmp_path):
     shadow = tmp_path / "foo.md"
-    shadow.write_text("## `foo`\n\n- d\n")
+    shadow.write_text("## `foo`\n\n- d\n", encoding="utf-8")
     assert dream_reconcile._shadow_language(str(shadow)) == "Unknown"
 
 
@@ -931,15 +931,15 @@ def test_shadow_language_reads_from_coupon_demo(dream_reconcile, coupon_demo):
 
 def test_rebuild_top_index_dry_run_does_not_write(dream_reconcile, coupon_demo):
     index_path = coupon_demo / ".shadow" / "_index.md"
-    original = index_path.read_text()
+    original = index_path.read_text(encoding="utf-8")
     dream_reconcile.rebuild_top_index(str(coupon_demo), dry_run=True)
-    assert index_path.read_text() == original
+    assert index_path.read_text(encoding="utf-8") == original
 
 
 def test_rebuild_top_index_regenerates_coupon_demo_counts(dream_reconcile, coupon_demo):
     """Regenerated header must report the same totals as the committed file."""
     index_path = coupon_demo / ".shadow" / "_index.md"
-    original = index_path.read_text()
+    original = index_path.read_text(encoding="utf-8")
 
     # Sanity-check the committed file states the expected counts.
     assert "Total files: 3" in original
@@ -949,7 +949,7 @@ def test_rebuild_top_index_regenerates_coupon_demo_counts(dream_reconcile, coupo
     assert "Dream cycles: 3" in original
 
     dream_reconcile.rebuild_top_index(str(coupon_demo), dry_run=False)
-    new = index_path.read_text()
+    new = index_path.read_text(encoding="utf-8")
 
     assert "Total files: 3" in new
     assert "Symbols: 9" in new
@@ -966,7 +966,7 @@ def test_rebuild_top_index_regenerates_coupon_demo_counts(dream_reconcile, coupo
 def test_rebuild_top_index_preserves_init_provenance(dream_reconcile, coupon_demo):
     index_path = coupon_demo / ".shadow" / "_index.md"
     dream_reconcile.rebuild_top_index(str(coupon_demo), dry_run=False)
-    new = index_path.read_text()
+    new = index_path.read_text(encoding="utf-8")
     assert "Initially generated by shadow-frog-init on 2026-04-20" in new
     assert "Last updated by shadow-frog-dream on" in new
 
@@ -987,10 +987,10 @@ def test_rebuild_top_index_includes_underscore_prefixed_source_dirs(
     (shadow / "_meta").mkdir(parents=True)
     (shadow / "src" / "_internal").mkdir(parents=True)
     (shadow / "src" / "_internal" / "helper.py.md").write_text(
-        "# Shadow\n## `helper`\n\n- d1\n\n## Cross-References\n\n_No discoveries yet._\n"
+        "# Shadow\n## `helper`\n\n- d1\n\n## Cross-References\n\n_No discoveries yet._\n", encoding="utf-8"
     )
     dream_reconcile.rebuild_top_index(str(tmp_path), dry_run=False)
-    new = (shadow / "_index.md").read_text()
+    new = (shadow / "_index.md").read_text(encoding="utf-8")
     assert "src/_internal/helper.py" in new
     assert "Total files: 1" in new
 
@@ -1068,6 +1068,7 @@ def test_cli_help_exits_zero():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--help"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "Dream reconciliation" in result.stdout
@@ -1088,6 +1089,7 @@ def test_cli_dry_run_with_no_dream_branches(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "No new branches" in result.stdout
@@ -1099,6 +1101,7 @@ def test_cli_unknown_argument_exits_nonzero():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--bogus-flag"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 1
     assert "Unknown argument" in result.stderr
@@ -1181,7 +1184,7 @@ def test_git_check_false_swallows_error(dream_reconcile, tmp_git_repo):
 
 def test_git_show_returns_file_content(dream_reconcile, tmp_git_repo):
     env = _seed_repo(tmp_git_repo)
-    (tmp_git_repo / "hello.txt").write_text("hello world\n")
+    (tmp_git_repo / "hello.txt").write_text("hello world\n", encoding="utf-8")
     _git("add", "-A", cwd=tmp_git_repo, env=env)
     _git("commit", "-q", "-m", "add hello", cwd=tmp_git_repo, env=env)
     out = dream_reconcile.git_show("HEAD", "hello.txt", cwd=str(tmp_git_repo))
@@ -1279,8 +1282,8 @@ def test_merge_discoveries_creates_per_file_shadows(dream_reconcile, tmp_path):
     assert merged == 3
     assert skipped == 0
 
-    cart = (repo / ".shadow" / "src" / "cart.py.md").read_text()
-    util = (repo / ".shadow" / "lib" / "util.py.md").read_text()
+    cart = (repo / ".shadow" / "src" / "cart.py.md").read_text(encoding="utf-8")
+    util = (repo / ".shadow" / "lib" / "util.py.md").read_text(encoding="utf-8")
 
     assert "## `add_item`" in cart
     assert "## `checkout`" in cart
@@ -1303,7 +1306,7 @@ def test_merge_discoveries_adds_dream_report_marker_to_each(
     dream_reconcile.merge_discoveries(
         str(repo), [(f"dream/proj/{dream_id}", dream_id, manifest)],
     )
-    body = (repo / ".shadow" / "a.py.md").read_text()
+    body = (repo / ".shadow" / "a.py.md").read_text(encoding="utf-8")
     assert body.count(f"Dream report: `_dreams/{dream_id}/`") == 2
 
 
@@ -1387,7 +1390,7 @@ def test_merge_discoveries_creates_cross_cutting_file_with_back_pointers(
 
     cross = repo / ".shadow" / "_cross" / "auth-lifecycle.md"
     assert cross.is_file()
-    body = cross.read_text()
+    body = cross.read_text(encoding="utf-8")
     assert body.startswith("# Auth Lifecycle\n")
     assert "**Category**: behavior" in body
     assert "`src/auth.py::login`" in body
@@ -1395,8 +1398,8 @@ def test_merge_discoveries_creates_cross_cutting_file_with_back_pointers(
     assert "_(verified, source: exploration)_" in body
 
     # Each referenced per-file shadow must have a back-pointer.
-    auth = (repo / ".shadow" / "src" / "auth.py.md").read_text()
-    sess = (repo / ".shadow" / "lib" / "session.py.md").read_text()
+    auth = (repo / ".shadow" / "src" / "auth.py.md").read_text(encoding="utf-8")
+    sess = (repo / ".shadow" / "lib" / "session.py.md").read_text(encoding="utf-8")
     assert "[Auth Lifecycle](../_cross/auth-lifecycle.md)" in auth
     assert "[Auth Lifecycle](../_cross/auth-lifecycle.md)" in sess
     assert f"dream: {dream_id}" in auth
@@ -1450,7 +1453,7 @@ def test_merge_discoveries_skips_existing_cross_cutting_file(
     repo = tmp_path
     (repo / ".shadow" / "_cross").mkdir(parents=True)
     existing = repo / ".shadow" / "_cross" / "preexist.md"
-    existing.write_text("# Old Title\n\n**Refs**:\n- `x.py::y`\n")
+    existing.write_text("# Old Title\n\n**Refs**:\n- `x.py::y`\n", encoding="utf-8")
 
     dream_id = "20260420-000800Z-preexist"
     manifest = _manifest_with(dream_id, cross_cutting=[
@@ -1465,11 +1468,11 @@ def test_merge_discoveries_skips_existing_cross_cutting_file(
     # No new cross file created — but the back-pointer to x.py is still added.
     assert merged == 0
     assert skipped == 1
-    assert "# Old Title" in existing.read_text()
+    assert "# Old Title" in existing.read_text(encoding="utf-8")
     # And the back-pointer landed.
     assert "[Old Title](_cross/preexist.md)" in (
         repo / ".shadow" / "x.py.md"
-    ).read_text()
+    ).read_text(encoding="utf-8")
 
 
 def test_merge_discoveries_skips_cross_ref_without_double_colon(
@@ -1533,7 +1536,7 @@ def test_merge_discoveries_multiple_manifests(dream_reconcile, tmp_path):
         ],
     )
     assert merged == 2
-    body = (repo / ".shadow" / "a.py.md").read_text()
+    body = (repo / ".shadow" / "a.py.md").read_text(encoding="utf-8")
     assert "## `x`" in body
     assert "## `y`" in body
     assert f"_dreams/{d1}/" in body
@@ -1562,10 +1565,10 @@ def test_mirror_reports_copies_report_and_patch(dream_reconcile, tmp_git_repo):
     assert mirrored == 1
     assert corrupted == []
     dream_dir = tmp_git_repo / ".shadow" / "_dreams" / dream_id
-    assert (dream_dir / "report.md").read_text() == report
-    assert (dream_dir / "patch.diff").read_text() == patch
+    assert (dream_dir / "report.md").read_text(encoding="utf-8") == report
+    assert (dream_dir / "patch.diff").read_text(encoding="utf-8") == patch
     # Manifest is rewritten from the in-memory dict.
-    saved_manifest = json.loads((dream_dir / "manifest.json").read_text())
+    saved_manifest = json.loads((dream_dir / "manifest.json").read_text(encoding="utf-8"))
     assert saved_manifest["dream_id"] == dream_id
 
 
@@ -1668,7 +1671,7 @@ def test_mirror_reports_detects_dream_id_mismatch(dream_reconcile, tmp_git_repo)
     assert mirrored == 1
     assert corrupted == [(dream_id, wrong_id)]
     dream_dir = tmp_git_repo / ".shadow" / "_dreams" / dream_id
-    body = (dream_dir / "report.md").read_text()
+    body = (dream_dir / "report.md").read_text(encoding="utf-8")
     assert "Corrupted Report" in body
     assert wrong_id in body
     # The manifest must still be mirrored despite the corrupt report.
@@ -1718,7 +1721,7 @@ def test_mirror_reports_multiple_manifests(dream_reconcile, tmp_git_repo):
     assert mirrored == 2
     for d in (d1, d2):
         body = (tmp_git_repo / ".shadow" / "_dreams" / d /
-                "report.md").read_text()
+                "report.md").read_text(encoding="utf-8")
         assert f"# {d}" in body
 
 
@@ -1737,7 +1740,7 @@ def test_update_index_bootstraps_when_missing(dream_reconcile, tmp_git_repo):
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
     )
-    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert "# Dream Experiment Archive" in idx
     assert "| dream_id | category | verdict |" in idx
     assert f"| {dream_id} | bug hunting | useful |" in idx
@@ -1758,7 +1761,7 @@ def test_update_index_preserves_existing_rows(dream_reconcile, tmp_git_repo):
         str(tmp_git_repo),
         [(f"dream/proj/{new_id}", new_id, _default_manifest(new_id))],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert "20260101-000000Z-alpha" in body
     assert "20260102-000000Z-beta" in body
     assert "20260103-000000Z-gamma" in body
@@ -1777,7 +1780,7 @@ def test_update_index_records_real_tip_commit(dream_reconcile, tmp_git_repo):
         str(tmp_git_repo),
         [(branch, dream_id, _default_manifest(dream_id))],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     row = [l for l in body.splitlines() if dream_id in l][0]
     assert f"| {expected_tip} |" in row
 
@@ -1793,14 +1796,14 @@ def test_update_index_dry_run_does_not_write(dream_reconcile, tmp_git_repo):
     idx_path = tmp_git_repo / ".shadow" / "_dreams" / "_index.md"
     # Pre-seed the file so the bootstrap path doesn't fire.
     idx_path.parent.mkdir(parents=True, exist_ok=True)
-    idx_path.write_text("# Dream Index\n\nold body\n")
-    before = idx_path.read_text()
+    idx_path.write_text("# Dream Index\n\nold body\n", encoding="utf-8")
+    before = idx_path.read_text(encoding="utf-8")
     dream_reconcile.update_index(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
         dry_run=True,
     )
-    assert idx_path.read_text() == before
+    assert idx_path.read_text(encoding="utf-8") == before
 
 
 @pytest.mark.slow
@@ -1828,7 +1831,7 @@ def test_update_index_uses_report_heading_when_manifest_title_missing(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, manifest)],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert "Beautiful Title From Report" in body
 
 
@@ -1848,7 +1851,7 @@ def test_update_index_falls_back_to_dream_id_when_no_title(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, manifest)],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert f"| Dream {dream_id} |" in body
 
 
@@ -1865,7 +1868,7 @@ def test_update_index_strips_pipe_chars_from_title(dream_reconcile, tmp_git_repo
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, manifest)],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     row = [l for l in body.splitlines() if dream_id in l][0]
     # Sanitized: pipes replaced with hyphens; row still has exactly the
     # canonical 8 separators ('| ' + 7 columns + ' |').
@@ -1889,7 +1892,7 @@ def test_update_index_normalizes_category_with_parens(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, manifest)],
     )
-    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    body = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     row = [l for l in body.splitlines() if dream_id in l][0]
     assert "| bug hunting |" in row
     assert "(notes" not in row
@@ -1913,7 +1916,7 @@ def test_update_state_bootstraps_missing_state_json(
     )
     state_path = tmp_git_repo / ".shadow" / "_meta" / "state.json"
     assert state_path.is_file()
-    state = json.loads(state_path.read_text())
+    state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["dream_cycles_completed"] == 1
     assert state["last_update_type"] == "dream"
     assert "last_update_at" in state
@@ -1928,13 +1931,13 @@ def test_update_state_increments_dream_cycles(dream_reconcile, tmp_git_repo):
     (state_dir / "state.json").write_text(json.dumps({
         "version": 1, "dream_cycles_completed": 5,
         "total_files": 0, "total_symbols": 0, "total_discoveries": 0,
-    }))
+    }), encoding="utf-8")
     dream_id = "20260420-040100Z-inc"
     dream_reconcile.update_state(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
     )
-    state = json.loads((state_dir / "state.json").read_text())
+    state = json.loads((state_dir / "state.json").read_text(encoding="utf-8"))
     assert state["dream_cycles_completed"] == 6
     assert state["last_update_type"] == "dream"
 
@@ -1952,17 +1955,17 @@ def test_update_state_recomputes_totals_excludes_internal_dirs(
         "# Shadow\n"
         "## `foo`\n\n- d1\n- d2\n\n"
         "## `bar`\n\n- d3\n\n"
-        "## Cross-References\n\n- [bp](../_cross/x.md)\n"
+        "## Cross-References\n\n- [bp](../_cross/x.md)\n", encoding="utf-8"
     )
     # Cross-cutting (should NOT contribute).
     (shadow / "_cross").mkdir()
     (shadow / "_cross" / "x.md").write_text(
-        "# X\n## `should_not_count`\n- bogus\n"
+        "# X\n## `should_not_count`\n- bogus\n", encoding="utf-8"
     )
     # Dream report (should NOT contribute).
     (shadow / "_dreams" / "20260420-040200Z-x").mkdir(parents=True)
     (shadow / "_dreams" / "20260420-040200Z-x" / "report.md").write_text(
-        "## `also_not_counted`\n- bogus\n"
+        "## `also_not_counted`\n- bogus\n", encoding="utf-8"
     )
     dream_id = "20260420-040200Z-totals"
     dream_reconcile.update_state(
@@ -1970,7 +1973,7 @@ def test_update_state_recomputes_totals_excludes_internal_dirs(
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
     )
     state = json.loads(
-        (shadow / "_meta" / "state.json").read_text()
+        (shadow / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     assert state["total_files"] == 1
     assert state["total_symbols"] == 2     # foo + bar
@@ -1992,7 +1995,7 @@ def test_update_state_counts_underscore_prefixed_source_dirs(
     (shadow / "src" / "_internal" / "helper.py.md").write_text(
         "# Shadow\n"
         "## `helper`\n\n- d1\n- d2\n\n"
-        "## Cross-References\n\n_No discoveries yet._\n"
+        "## Cross-References\n\n_No discoveries yet._\n", encoding="utf-8"
     )
     dream_id = "20260420-040250Z-underscore"
     dream_reconcile.update_state(
@@ -2000,7 +2003,7 @@ def test_update_state_counts_underscore_prefixed_source_dirs(
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
     )
     state = json.loads(
-        (shadow / "_meta" / "state.json").read_text()
+        (shadow / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     assert state["total_files"] == 1
     assert state["total_symbols"] == 1
@@ -2033,15 +2036,15 @@ def test_update_state_dry_run_does_not_modify_existing(
         "version": 1, "dream_cycles_completed": 7,
         "total_files": 9, "total_symbols": 99, "total_discoveries": 42,
     }
-    (state_dir / "state.json").write_text(json.dumps(payload))
-    original = (state_dir / "state.json").read_text()
+    (state_dir / "state.json").write_text(json.dumps(payload), encoding="utf-8")
+    original = (state_dir / "state.json").read_text(encoding="utf-8")
     dream_id = "20260420-040400Z-drye"
     dream_reconcile.update_state(
         str(tmp_git_repo),
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
         dry_run=True,
     )
-    assert (state_dir / "state.json").read_text() == original
+    assert (state_dir / "state.json").read_text(encoding="utf-8") == original
     assert "Would update state.json" in capsys.readouterr().out
 
 
@@ -2055,7 +2058,7 @@ def test_update_state_records_last_commit_sha(dream_reconcile, tmp_git_repo):
         [(f"dream/proj/{dream_id}", dream_id, _default_manifest(dream_id))],
     )
     state = json.loads(
-        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text()
+        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     assert state["last_commit"] == head_sha
 
@@ -2132,7 +2135,7 @@ def test_cleanup_branches_refuses_when_head_not_pushed(
         f"| {dream_id} | bug hunting | useful | T | {branch} | main | abc1234 |\n",
     )
     # Make a new local commit on main that is NOT pushed.
-    (tmp_git_repo / "drift.txt").write_text("unpushed\n")
+    (tmp_git_repo / "drift.txt").write_text("unpushed\n", encoding="utf-8")
     _git("add", "-A", cwd=tmp_git_repo, env=env)
     _git("commit", "-q", "-m", "local-only", cwd=tmp_git_repo, env=env)
 
@@ -2293,13 +2296,13 @@ def test_add_cross_reference_backpointer_appends_when_other_links_exist(
     shadow.write_text(
         "## `foo`\n\n- discovery\n\n"
         "## Cross-References\n\n"
-        "- [Existing](_cross/existing.md) (dream: 20260101-prev)\n"
+        "- [Existing](_cross/existing.md) (dream: 20260101-prev)\n", encoding="utf-8"
     )
     written = dream_reconcile.add_cross_reference_backpointer(
         str(repo), "foo.py", "fresh", "Fresh Title", "20260420-091000Z-new",
     )
     assert written is True
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "[Existing](_cross/existing.md)" in body
     assert "[Fresh Title](_cross/fresh.md)" in body
     # The pre-existing entry is before the new one.
@@ -2318,12 +2321,12 @@ def test_add_cross_reference_backpointer_inserts_before_next_heading(
         "## `z`\n\n- d\n\n"
         "## Cross-References\n\n"
         "- [Pre](_cross/pre.md)\n\n"
-        "## Other Section\n\nstuff\n"
+        "## Other Section\n\nstuff\n", encoding="utf-8"
     )
     dream_reconcile.add_cross_reference_backpointer(
         str(repo), "z.py", "new", "New", "20260420-091500Z-y",
     )
-    body = shadow.read_text()
+    body = shadow.read_text(encoding="utf-8")
     assert "[New](_cross/new.md)" in body
     # Inserted before `## Other Section`.
     assert body.index("[New]") < body.index("## Other Section")
@@ -2350,6 +2353,7 @@ def test_cli_namespace_requires_value():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--namespace"],
         capture_output=True, text=True,
+        encoding="utf-8",
     )
     assert result.returncode == 1
     assert "--namespace requires a value" in result.stderr
@@ -2382,18 +2386,19 @@ def test_cli_full_happy_path_reconciles_two_dreams(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo)],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "All 2 dreams verified" in result.stdout
     # state.json updated.
     state = json.loads(
-        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text()
+        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     assert state["dream_cycles_completed"] == 1
     assert state["last_update_type"] == "dream"
     assert state["total_discoveries"] >= 2
     # _index.md has both dreams.
-    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert d1 in idx
     assert d2 in idx
     # Per-dream mirror dirs.
@@ -2402,13 +2407,13 @@ def test_cli_full_happy_path_reconciles_two_dreams(tmp_git_repo):
         assert (d_dir / "manifest.json").is_file()
         assert (d_dir / "report.md").is_file()
     # Per-file shadow exists.
-    cart = (tmp_git_repo / ".shadow" / "src" / "cart.py.md").read_text()
+    cart = (tmp_git_repo / ".shadow" / "src" / "cart.py.md").read_text(encoding="utf-8")
     assert "## `add_item`" in cart
     assert "## `checkout`" in cart
     # Cross-cutting file exists.
     assert (tmp_git_repo / ".shadow" / "_cross" / "cart-flow.md").is_file()
     # Top-level _index.md regenerated with dream cycles.
-    top = (tmp_git_repo / ".shadow" / "_index.md").read_text()
+    top = (tmp_git_repo / ".shadow" / "_index.md").read_text(encoding="utf-8")
     assert "Dream cycles: 1" in top
 
 
@@ -2428,6 +2433,7 @@ def test_cli_dry_run_makes_no_persistent_changes(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "DRY RUN" in result.stdout
@@ -2458,6 +2464,7 @@ def test_cli_namespace_filters_branches(tmp_git_repo):
         [sys.executable, str(SCRIPT), str(tmp_git_repo),
          "--namespace", "inside", "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert in_id in result.stdout
@@ -2485,13 +2492,14 @@ def test_cli_skips_invalid_manifest_and_continues(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo)],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert good in result.stdout
     # The bad one is mentioned as SKIP, not crashed.
     assert "SKIP" in result.stdout and bad in result.stdout
     # And only the good one made it into _index.md.
-    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert good in idx
     assert bad not in idx
 
@@ -2505,6 +2513,7 @@ def test_cli_no_dreams_exits_zero_with_message(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo)],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "No new branches" in result.stdout
@@ -2520,6 +2529,7 @@ def test_cli_not_in_git_repo_exits_nonzero(tmp_path):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(not_a_repo / "nope")],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 1
     assert "Not in a git repository" in result.stderr
@@ -2535,6 +2545,7 @@ def test_cli_no_positional_uses_git_toplevel(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--dry-run"],
         capture_output=True, text=True, env=full_env, cwd=str(tmp_git_repo),
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "No new branches" in result.stdout
@@ -2546,12 +2557,13 @@ def test_cli_namespace_from_dotenv_file(tmp_git_repo):
     """If DREAM_NAMESPACE is unset and a `.env` provides one, use it."""
     env = _seed_repo(tmp_git_repo)
     _add_bare_remote(tmp_git_repo, env)
-    (tmp_git_repo / ".env").write_text("DREAM_NAMESPACE=fromdotenv\n")
+    (tmp_git_repo / ".env").write_text("DREAM_NAMESPACE=fromdotenv\n", encoding="utf-8")
     full_env = _cli_env()
     full_env.pop("DREAM_NAMESPACE", None)
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Namespace: fromdotenv" in result.stdout
@@ -2563,13 +2575,14 @@ def test_cli_namespace_from_task_info_json(tmp_git_repo):
     env = _seed_repo(tmp_git_repo)
     _add_bare_remote(tmp_git_repo, env)
     (tmp_git_repo / "TASK_INFO.json").write_text(
-        json.dumps({"dream_namespace": "fromtaskinfo"})
+        json.dumps({"dream_namespace": "fromtaskinfo"}), encoding="utf-8"
     )
     full_env = _cli_env()
     full_env.pop("DREAM_NAMESPACE", None)
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Namespace: fromtaskinfo" in result.stdout
@@ -2585,6 +2598,7 @@ def test_cli_namespace_falls_back_to_repo_basename(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--dry-run"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     # The fixture's repo dir is named "repo".
@@ -2600,6 +2614,7 @@ def test_cli_verify_only_empty_index_exits_zero(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--verify-only"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "No reconciled dreams" in result.stdout
@@ -2623,6 +2638,7 @@ def test_cli_verify_only_passes_for_fully_reconciled_dream(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--verify-only"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "All 1 indexed dreams verified" in result.stdout
@@ -2646,6 +2662,7 @@ def test_cli_verify_only_reports_missing_artifacts(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo), "--verify-only"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 1
     assert "Verification FAILED" in result.stdout
@@ -2670,6 +2687,7 @@ def test_cli_cleanup_branches_after_reconcile(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo)],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     _git("add", "-A", cwd=tmp_git_repo, env=env)
@@ -2681,6 +2699,7 @@ def test_cli_cleanup_branches_after_reconcile(tmp_git_repo):
         [sys.executable, str(SCRIPT), str(tmp_git_repo),
          "--cleanup-branches"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0, result.stdout + result.stderr
     assert "Deleted: 1" in result.stdout
@@ -2701,6 +2720,7 @@ def test_cli_cleanup_no_new_no_indexed_exits_zero(tmp_git_repo):
         [sys.executable, str(SCRIPT), str(tmp_git_repo),
          "--cleanup-branches"],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "Nothing in _index.md to clean up" in result.stdout
@@ -2720,7 +2740,7 @@ def test_cli_corrupted_manifest_json_skipped(tmp_git_repo):
     _git("checkout", "-q", "-b", branch, cwd=tmp_git_repo, env=env)
     dream_dir = tmp_git_repo / ".shadow" / "_dreams" / bad_id
     dream_dir.mkdir(parents=True)
-    (dream_dir / "manifest.json").write_text("{this is not json")
+    (dream_dir / "manifest.json").write_text("{this is not json", encoding="utf-8")
     _git("add", "-A", cwd=tmp_git_repo, env=env)
     _git("commit", "-q", "-m", "bad json", cwd=tmp_git_repo, env=env)
     _git("push", "-q", "origin", branch, cwd=tmp_git_repo, env=env)
@@ -2730,6 +2750,7 @@ def test_cli_corrupted_manifest_json_skipped(tmp_git_repo):
     result = subprocess.run(
         [sys.executable, str(SCRIPT), str(tmp_git_repo)],
         capture_output=True, text=True, env=full_env,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "SKIP" in result.stdout
@@ -2781,7 +2802,7 @@ class TestUpdateIndexDryRunIsReadOnly:
             "| dream_id | category | verdict | title | branch | parent | tip_commit |\n"
             "|----------|----------|---------|-------|--------|--------|------------|\n"
         )
-        index_path.write_text(original)
+        index_path.write_text(original, encoding="utf-8")
 
         manifests = [
             ("dream/proj/xx", "20260420-1500Z-feat",
@@ -2789,7 +2810,7 @@ class TestUpdateIndexDryRunIsReadOnly:
         ]
         dream_reconcile.update_index(str(tmp_git_repo), manifests, dry_run=True)
 
-        assert index_path.read_text() == original
+        assert index_path.read_text(encoding="utf-8") == original
 
     def test_dry_run_still_prints_preview(
         self, dream_reconcile, tmp_git_repo, capsys
@@ -2860,7 +2881,7 @@ class TestMergeRefsIntoCrossFile:
         body = ["# Title", "", "**Category**: pattern", "**Refs**:"]
         body += [f"- `{r}`" for r in refs]
         body += ["", "**Discovery**: something", ""]
-        p.write_text("\n".join(body))
+        p.write_text("\n".join(body), encoding="utf-8")
         return p
 
     def test_unions_new_refs(self, dream_reconcile, tmp_path):
@@ -2869,7 +2890,7 @@ class TestMergeRefsIntoCrossFile:
             str(p), ["src/b.py::g", "src/a.py::f"]
         )
         assert changed is True
-        text = p.read_text()
+        text = p.read_text(encoding="utf-8")
         assert "- `src/a.py::f`" in text
         assert "- `src/b.py::g`" in text
         # No duplication of the already-present ref.
@@ -2877,12 +2898,12 @@ class TestMergeRefsIntoCrossFile:
 
     def test_no_change_when_all_present(self, dream_reconcile, tmp_path):
         p = self._write_cross(tmp_path, ["src/a.py::f"])
-        before = p.read_text()
+        before = p.read_text(encoding="utf-8")
         changed = dream_reconcile._merge_refs_into_cross_file(
             str(p), ["src/a.py::f"]
         )
         assert changed is False
-        assert p.read_text() == before
+        assert p.read_text(encoding="utf-8") == before
 
     def test_missing_file_returns_false(self, dream_reconcile, tmp_path):
         assert dream_reconcile._merge_refs_into_cross_file(
@@ -2891,12 +2912,12 @@ class TestMergeRefsIntoCrossFile:
 
     def test_no_refs_block_returns_false(self, dream_reconcile, tmp_path):
         p = tmp_path / "norefs.md"
-        p.write_text("# Title\n\nNo refs section here.\n")
+        p.write_text("# Title\n\nNo refs section here.\n", encoding="utf-8")
         assert dream_reconcile._merge_refs_into_cross_file(
             str(p), ["x::y"]
         ) is False
         # File untouched.
-        assert "No refs section here." in p.read_text()
+        assert "No refs section here." in p.read_text(encoding="utf-8")
 
 
 # ===========================================================================
@@ -3044,8 +3065,8 @@ def test_cleanup_branches_worktree_gc_falls_back_on_dead_gitdir(
     base = tmp_path / "wt-base"
     worktree_dir = base / "proj" / "dream-dead"
     worktree_dir.mkdir(parents=True)
-    (worktree_dir / ".git").write_text("gitdir: /nonexistent/wt-dir\n")
-    (worktree_dir / "leaked.pyc").write_text("# leak me\n")
+    (worktree_dir / ".git").write_text("gitdir: /nonexistent/wt-dir\n", encoding="utf-8")
+    (worktree_dir / "leaked.pyc").write_text("# leak me\n", encoding="utf-8")
 
     monkeypatch.setenv("DREAM_WORKTREE_BASE", str(base))
 
@@ -3089,7 +3110,7 @@ def test_cleanup_branches_worktree_gc_refuses_unsafe_base(
     # Decoy at /tmp/proj/dream-unsafe — must NOT be touched.
     decoy = tmp_path / "should-not-be-deleted"
     decoy.mkdir()
-    (decoy / "important.txt").write_text("keep me\n")
+    (decoy / "important.txt").write_text("keep me\n", encoding="utf-8")
 
     # Point DREAM_WORKTREE_BASE at /tmp — gate must refuse.
     monkeypatch.setenv("DREAM_WORKTREE_BASE", "/tmp")
@@ -3106,7 +3127,7 @@ def test_cleanup_branches_worktree_gc_refuses_unsafe_base(
     assert "Skipping worktree GC" in captured.out or "sensitive root" in captured.out
     # Decoy is untouched.
     assert decoy.is_dir()
-    assert (decoy / "important.txt").read_text() == "keep me\n"
+    assert (decoy / "important.txt").read_text(encoding="utf-8") == "keep me\n"
 
 
 @pytest.mark.slow
@@ -3247,7 +3268,7 @@ def test_cleanup_branches_does_not_clobber_concurrent_slug_collision(
          cwd=tmp_git_repo, env=env)
     assert shared_path.is_dir()
     # Add a "user file" — proxy for uncommitted work that must survive.
-    (shared_path / "uncommitted-work.txt").write_text("PRECIOUS WORK\n")
+    (shared_path / "uncommitted-work.txt").write_text("PRECIOUS WORK\n", encoding="utf-8")
 
     # Reconcile A — its GC must NOT take down B's worktree.
     deleted, _ = dream_reconcile.cleanup_branches(
@@ -3263,7 +3284,7 @@ def test_cleanup_branches_does_not_clobber_concurrent_slug_collision(
         "B's live worktree was DESTROYED by A's reconciler GC — "
         "cross-deletion regression (S2)"
     )
-    assert (shared_path / "uncommitted-work.txt").read_text() == "PRECIOUS WORK\n", (
+    assert (shared_path / "uncommitted-work.txt").read_text(encoding="utf-8") == "PRECIOUS WORK\n", (
         "user's uncommitted work in B's worktree was lost"
     )
     # B's branch must still exist too.

--- a/tests/skills/shadow_frog_init/test_shadow_init.py
+++ b/tests/skills/shadow_frog_init/test_shadow_init.py
@@ -42,6 +42,7 @@ def _run_shadow_init(repo_root, *args, timeout=60):
     return subprocess.run(
         [sys.executable, str(SCRIPT), "--root", str(repo_root), *args],
         capture_output=True, text=True, timeout=timeout, cwd=str(repo_root),
+        encoding="utf-8",
     )
 
 
@@ -218,22 +219,22 @@ def test_walk_files_empty_repo(shadow_init, tmp_path):
 def test_walk_files_one_file(shadow_init, tmp_path):
     repo = tmp_path / "one_file"
     repo.mkdir()
-    (repo / "foo.py").write_text("x = 1\n")
+    (repo / "foo.py").write_text("x = 1\n", encoding="utf-8")
     assert shadow_init._walk_files(str(repo)) == ["foo.py"]
 
 
 def test_walk_files_skips_excluded_and_dotfile_dirs(shadow_init, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
-    (repo / "foo.py").write_text("x = 1\n")
+    (repo / "foo.py").write_text("x = 1\n", encoding="utf-8")
     (repo / "src").mkdir()
-    (repo / "src" / "main.py").write_text("y = 2\n")
+    (repo / "src" / "main.py").write_text("y = 2\n", encoding="utf-8")
     # Excluded dir
     (repo / "node_modules").mkdir()
-    (repo / "node_modules" / "bundle.js").write_text("z = 3\n")
+    (repo / "node_modules" / "bundle.js").write_text("z = 3\n", encoding="utf-8")
     # Hidden dir (skipped by _walk_files's leading-dot filter)
     (repo / ".git").mkdir()
-    (repo / ".git" / "config").write_text("[core]\n")
+    (repo / ".git" / "config").write_text("[core]\n", encoding="utf-8")
 
     result = sorted(shadow_init._walk_files(str(repo)))
     assert "foo.py" in result
@@ -252,19 +253,19 @@ def test_load_shadowignore_no_file(shadow_init, tmp_path):
 
 
 def test_load_shadowignore_empty_file(shadow_init, tmp_path):
-    (tmp_path / ".shadowignore").write_text("")
+    (tmp_path / ".shadowignore").write_text("", encoding="utf-8")
     matcher = shadow_init._load_shadowignore(tmp_path)
     assert matcher("anything.py") is False
 
 
 def test_load_shadowignore_comments_only(shadow_init, tmp_path):
-    (tmp_path / ".shadowignore").write_text("# header comment\n\n# another\n")
+    (tmp_path / ".shadowignore").write_text("# header comment\n\n# another\n", encoding="utf-8")
     matcher = shadow_init._load_shadowignore(tmp_path)
     assert matcher("anything.py") is False
 
 
 def test_load_shadowignore_pattern_matches(shadow_init, tmp_path):
-    (tmp_path / ".shadowignore").write_text("*.log\nsecret/\n")
+    (tmp_path / ".shadowignore").write_text("*.log\nsecret/\n", encoding="utf-8")
     matcher = shadow_init._load_shadowignore(tmp_path)
     assert matcher("foo.log") is True
     assert matcher("nested/path/error.log") is True
@@ -273,7 +274,7 @@ def test_load_shadowignore_pattern_matches(shadow_init, tmp_path):
 
 def test_load_shadowignore_negation_does_not_crash(shadow_init, tmp_path):
     # Negation is valid gitwildmatch syntax — the matcher must not raise.
-    (tmp_path / ".shadowignore").write_text("*.log\n!keep.log\n")
+    (tmp_path / ".shadowignore").write_text("*.log\n!keep.log\n", encoding="utf-8")
     matcher = shadow_init._load_shadowignore(tmp_path)
     # Both calls must succeed (we don't assert specific values because
     # pathspec respects negation but the fnmatch fallback does not).
@@ -287,12 +288,12 @@ def test_load_shadowignore_negation_does_not_crash(shadow_init, tmp_path):
 
 @pytest.mark.slow
 def test_discover_files_end_to_end(shadow_init, tmp_git_repo):
-    (tmp_git_repo / "foo.py").write_text("def hello(): pass\n")
-    (tmp_git_repo / "bar.js").write_text("function world() {}\n")
-    (tmp_git_repo / "ignore.txt").write_text("not source\n")
+    (tmp_git_repo / "foo.py").write_text("def hello(): pass\n", encoding="utf-8")
+    (tmp_git_repo / "bar.js").write_text("function world() {}\n", encoding="utf-8")
+    (tmp_git_repo / "ignore.txt").write_text("not source\n", encoding="utf-8")
     sub = tmp_git_repo / "src"
     sub.mkdir()
-    (sub / "baz.py").write_text("x = 1\n")
+    (sub / "baz.py").write_text("x = 1\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "add files"],
                    cwd=tmp_git_repo, check=True)
@@ -310,15 +311,15 @@ def test_discover_files_end_to_end(shadow_init, tmp_git_repo):
 
 @pytest.mark.slow
 def test_discover_files_honors_shadowignore(shadow_init, tmp_git_repo):
-    (tmp_git_repo / "foo.py").write_text("def a(): pass\n")
-    (tmp_git_repo / "bar.py").write_text("def b(): pass\n")
+    (tmp_git_repo / "foo.py").write_text("def a(): pass\n", encoding="utf-8")
+    (tmp_git_repo / "bar.py").write_text("def b(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "init"],
                    cwd=tmp_git_repo, check=True)
 
     shadow_dir = tmp_git_repo / ".shadow"
     shadow_dir.mkdir()
-    (shadow_dir / ".shadowignore").write_text("bar.py\n")
+    (shadow_dir / ".shadowignore").write_text("bar.py\n", encoding="utf-8")
 
     result = shadow_init.discover_files(str(tmp_git_repo), shadow_dir)
     assert "foo.py" in result
@@ -739,7 +740,7 @@ def test_cli_dry_run_does_not_write_shadow(tmp_git_repo):
 def test_cli_creates_shadow_for_committed_file(tmp_git_repo):
     """End-to-end: a committed `foo.py` should yield a complete .shadow/ tree."""
     (tmp_git_repo / "foo.py").write_text(
-        "def hello():\n    return 'world'\n\nclass Greeter:\n    def hi(self):\n        return 'hi'\n"
+        "def hello():\n    return 'world'\n\nclass Greeter:\n    def hi(self):\n        return 'hi'\n", encoding="utf-8"
     )
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "add foo"],
@@ -760,7 +761,7 @@ def test_cli_creates_shadow_for_committed_file(tmp_git_repo):
     assert (shadow / "_cross").is_dir()
     assert (shadow / "_dreams").is_dir()
 
-    state = json.loads((shadow / "_meta" / "state.json").read_text())
+    state = json.loads((shadow / "_meta" / "state.json").read_text(encoding="utf-8"))
     assert isinstance(state["last_commit"], str)
     assert re.fullmatch(r"[0-9a-f]{40}", state["last_commit"]), (
         f"Expected 40-char hex SHA, got: {state['last_commit']!r}"
@@ -770,7 +771,7 @@ def test_cli_creates_shadow_for_committed_file(tmp_git_repo):
     assert state["last_update_type"] == "init"
     assert state["version"] == 1
 
-    shadow_content = (shadow / "foo.py.md").read_text()
+    shadow_content = (shadow / "foo.py.md").read_text(encoding="utf-8")
     assert "hello" in shadow_content
     assert "Greeter" in shadow_content
     assert "Python" in shadow_content
@@ -791,7 +792,7 @@ def test_cli_b2_no_commits_uses_none_sentinel(tmp_git_repo):
     )
 
     state_path = tmp_git_repo / ".shadow" / "_meta" / "state.json"
-    state = json.loads(state_path.read_text())
+    state = json.loads(state_path.read_text(encoding="utf-8"))
     assert state["last_commit"] == "none", (
         f"B2 regression: expected sentinel 'none', got {state['last_commit']!r}. "
         "An empty string here breaks downstream hooks that distinguish "
@@ -804,7 +805,7 @@ def test_cli_b2_no_commits_uses_none_sentinel(tmp_git_repo):
 def test_cli_refuses_to_overwrite_without_reset(tmp_git_repo):
     """If .shadow/ already exists, the script must refuse without --reset."""
     (tmp_git_repo / ".shadow").mkdir()
-    (tmp_git_repo / ".shadow" / "marker").write_text("preserve me\n")
+    (tmp_git_repo / ".shadow" / "marker").write_text("preserve me\n", encoding="utf-8")
 
     result = _run_shadow_init(tmp_git_repo)  # no --reset
     assert result.returncode == 1
@@ -931,9 +932,9 @@ def test_find_repo_root_inside_subdirectory(shadow_init, tmp_git_repo,
 # ---------------------------------------------------------------------------
 
 def test_walk_files_lists_all_non_excluded(shadow_init, tmp_path):
-    (tmp_path / "a.py").write_text("x")
+    (tmp_path / "a.py").write_text("x", encoding="utf-8")
     (tmp_path / "sub").mkdir()
-    (tmp_path / "sub" / "b.txt").write_text("y")
+    (tmp_path / "sub" / "b.txt").write_text("y", encoding="utf-8")
     result = shadow_init._walk_files(tmp_path)
     # Note: walk does NOT filter by extension — that's discover_files's job
     assert "a.py" in result
@@ -949,7 +950,7 @@ def test_walk_files_lists_all_non_excluded(shadow_init, tmp_path):
 def test_load_shadowignore_unreadable_file_warns(shadow_init, tmp_path,
                                                  reset_diagnostics):
     ignore = tmp_path / ".shadowignore"
-    ignore.write_text("*.log\n")
+    ignore.write_text("*.log\n", encoding="utf-8")
     ignore.chmod(0o000)
     try:
         matcher = reset_diagnostics._load_shadowignore(tmp_path)
@@ -969,9 +970,9 @@ def test_load_shadowignore_unreadable_file_warns(shadow_init, tmp_path,
 def test_discover_files_falls_back_to_walk_in_non_git_dir(shadow_init,
                                                           tmp_path):
     """ls-files fails outside git → walk fallback finds files anyway."""
-    (tmp_path / "foo.py").write_text("def x(): pass\n")
-    (tmp_path / "bar.js").write_text("function y(){}\n")
-    (tmp_path / "ignored.txt").write_text("not source\n")
+    (tmp_path / "foo.py").write_text("def x(): pass\n", encoding="utf-8")
+    (tmp_path / "bar.js").write_text("function y(){}\n", encoding="utf-8")
+    (tmp_path / "ignored.txt").write_text("not source\n", encoding="utf-8")
     result = shadow_init.discover_files(str(tmp_path), tmp_path / ".shadow")
     assert "foo.py" in result
     assert "bar.js" in result
@@ -1118,7 +1119,7 @@ def test_extract_swift_clamps_negative_brace_depth(shadow_init):
 
 def test_get_last_modified_returns_iso_date_for_committed_file(shadow_init,
                                                                tmp_git_repo):
-    (tmp_git_repo / "foo.py").write_text("x\n")
+    (tmp_git_repo / "foo.py").write_text("x\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1129,13 +1130,13 @@ def test_get_last_modified_returns_iso_date_for_committed_file(shadow_init,
 
 def test_get_last_modified_returns_unknown_in_non_git_dir(shadow_init,
                                                           tmp_path):
-    (tmp_path / "foo.py").write_text("x\n")
+    (tmp_path / "foo.py").write_text("x\n", encoding="utf-8")
     assert shadow_init.get_last_modified("foo.py", str(tmp_path)) == "unknown"
 
 
 def test_get_last_modified_returns_unknown_for_uncommitted(shadow_init,
                                                            tmp_git_repo):
-    (tmp_git_repo / "fresh.py").write_text("x\n")  # not committed
+    (tmp_git_repo / "fresh.py").write_text("x\n", encoding="utf-8")  # not committed
     assert shadow_init.get_last_modified("fresh.py",
                                          str(tmp_git_repo)) == "unknown"
 
@@ -1229,7 +1230,7 @@ def test_init_shadow_empty_git_repo_writes_none_sentinel(shadow_init,
     assert (shadow / "_index.md").is_file()
     assert (shadow / "_prefs.md").is_file()
 
-    state = json.loads((shadow / "_meta" / "state.json").read_text())
+    state = json.loads((shadow / "_meta" / "state.json").read_text(encoding="utf-8"))
     assert state["last_commit"] == "none"
     assert state["total_files"] == 0
     assert state["total_symbols"] == 0
@@ -1244,7 +1245,7 @@ def test_init_shadow_dreams_index_has_seven_column_header(shadow_init,
     """The _dreams/_index.md scaffold must use the 7-column schema that
     dream-reconcile.py / dream-lineage.py validate against."""
     shadow_init.init_shadow(str(tmp_git_repo))
-    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text()
+    idx = (tmp_git_repo / ".shadow" / "_dreams" / "_index.md").read_text(encoding="utf-8")
     assert "dream_id" in idx
     assert "category" in idx
     assert "verdict" in idx
@@ -1257,7 +1258,7 @@ def test_init_shadow_dreams_index_has_seven_column_header(shadow_init,
 def test_init_shadow_default_shadowignore_has_expected_content(shadow_init,
                                                                tmp_git_repo):
     shadow_init.init_shadow(str(tmp_git_repo))
-    sig = (tmp_git_repo / ".shadow" / ".shadowignore").read_text()
+    sig = (tmp_git_repo / ".shadow" / ".shadowignore").read_text(encoding="utf-8")
     assert "node_modules/" in sig
     assert "*.min.js" in sig
     assert ".shadow/" in sig
@@ -1266,22 +1267,22 @@ def test_init_shadow_default_shadowignore_has_expected_content(shadow_init,
 
 def test_init_shadow_prefs_default_content(shadow_init, tmp_git_repo):
     shadow_init.init_shadow(str(tmp_git_repo))
-    prefs = (tmp_git_repo / ".shadow" / "_prefs.md").read_text()
+    prefs = (tmp_git_repo / ".shadow" / "_prefs.md").read_text(encoding="utf-8")
     assert "# Preferences" in prefs
     assert "_No preferences recorded yet._" in prefs
 
 
 def test_init_shadow_mixed_language_project(shadow_init, tmp_git_repo):
     """Multi-language repo: every recognized source file gets a shadow."""
-    (tmp_git_repo / "main.py").write_text("def main(): pass\n")
-    (tmp_git_repo / "app.js").write_text("function start() {}\n")
-    (tmp_git_repo / "lib.go").write_text("package x\nfunc Hello() {}\n")
-    (tmp_git_repo / "mod.rb").write_text("class Foo\n  def bar\n  end\nend\n")
-    (tmp_git_repo / "thing.rs").write_text("pub fn run() {}\n")
-    (tmp_git_repo / "shell.sh").write_text("greet() { echo hi; }\n")
+    (tmp_git_repo / "main.py").write_text("def main(): pass\n", encoding="utf-8")
+    (tmp_git_repo / "app.js").write_text("function start() {}\n", encoding="utf-8")
+    (tmp_git_repo / "lib.go").write_text("package x\nfunc Hello() {}\n", encoding="utf-8")
+    (tmp_git_repo / "mod.rb").write_text("class Foo\n  def bar\n  end\nend\n", encoding="utf-8")
+    (tmp_git_repo / "thing.rs").write_text("pub fn run() {}\n", encoding="utf-8")
+    (tmp_git_repo / "shell.sh").write_text("greet() { echo hi; }\n", encoding="utf-8")
     sub = tmp_git_repo / "src"
     sub.mkdir()
-    (sub / "deep.ts").write_text("export function compute() {}\n")
+    (sub / "deep.ts").write_text("export function compute() {}\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "init"],
                    cwd=tmp_git_repo, check=True)
@@ -1293,12 +1294,12 @@ def test_init_shadow_mixed_language_project(shadow_init, tmp_git_repo):
                  "thing.rs.md", "shell.sh.md", "src/deep.ts.md"):
         assert (shadow / path).is_file(), f"missing shadow: {path}"
 
-    state = json.loads((shadow / "_meta" / "state.json").read_text())
+    state = json.loads((shadow / "_meta" / "state.json").read_text(encoding="utf-8"))
     assert state["total_files"] == 7
     assert state["total_symbols"] >= 7  # each file contributes >=1 symbol
     assert re.fullmatch(r"[0-9a-f]{40}", state["last_commit"])
 
-    index = (shadow / "_index.md").read_text()
+    index = (shadow / "_index.md").read_text(encoding="utf-8")
     for p in ("main.py", "app.js", "lib.go", "mod.rb",
               "thing.rs", "shell.sh", "src/deep.ts"):
         assert p in index
@@ -1307,16 +1308,16 @@ def test_init_shadow_mixed_language_project(shadow_init, tmp_git_repo):
 def test_init_shadow_state_counts_match_disk(shadow_init, tmp_git_repo):
     """state.json totals must match actual files/symbols on disk."""
     (tmp_git_repo / "a.py").write_text(
-        "def f1(): pass\ndef f2(): pass\nclass C:\n    def m(self): pass\n"
+        "def f1(): pass\ndef f2(): pass\nclass C:\n    def m(self): pass\n", encoding="utf-8"
     )
-    (tmp_git_repo / "b.py").write_text("def only(): pass\n")
+    (tmp_git_repo / "b.py").write_text("def only(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
 
     shadow_init.init_shadow(str(tmp_git_repo))
     state = json.loads(
-        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text()
+        (tmp_git_repo / ".shadow" / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     # Two source files
     assert state["total_files"] == 2
@@ -1328,18 +1329,18 @@ def test_init_shadow_refuses_when_shadow_exists_without_reset(shadow_init,
                                                               tmp_git_repo,
                                                               reset_diagnostics):
     (tmp_git_repo / ".shadow").mkdir()
-    (tmp_git_repo / ".shadow" / "marker").write_text("preserve\n")
+    (tmp_git_repo / ".shadow" / "marker").write_text("preserve\n", encoding="utf-8")
     ok = reset_diagnostics.init_shadow(str(tmp_git_repo), reset=False)
     assert ok is False
-    assert (tmp_git_repo / ".shadow" / "marker").read_text() == "preserve\n"
+    assert (tmp_git_repo / ".shadow" / "marker").read_text(encoding="utf-8") == "preserve\n"
     msgs = [m for lvl, m in reset_diagnostics._diagnostics if lvl == "error"]
     assert any("already exists" in m for m in msgs)
 
 
 def test_init_shadow_reset_replaces_existing(shadow_init, tmp_git_repo):
     (tmp_git_repo / ".shadow").mkdir()
-    (tmp_git_repo / ".shadow" / "stale.md").write_text("old\n")
-    (tmp_git_repo / "foo.py").write_text("def x(): pass\n")
+    (tmp_git_repo / ".shadow" / "stale.md").write_text("old\n", encoding="utf-8")
+    (tmp_git_repo / "foo.py").write_text("def x(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1352,7 +1353,7 @@ def test_init_shadow_reset_replaces_existing(shadow_init, tmp_git_repo):
 
 def test_init_shadow_dry_run_creates_no_files(shadow_init, tmp_git_repo,
                                               capsys):
-    (tmp_git_repo / "foo.py").write_text("def x(): pass\n")
+    (tmp_git_repo / "foo.py").write_text("def x(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1369,11 +1370,11 @@ def test_init_shadow_dry_run_with_existing_shadow_and_reset(shadow_init,
                                                             capsys):
     """dry_run + reset must report 'Would delete' without actually deleting."""
     (tmp_git_repo / ".shadow").mkdir()
-    (tmp_git_repo / ".shadow" / "keep.txt").write_text("preserved\n")
+    (tmp_git_repo / ".shadow" / "keep.txt").write_text("preserved\n", encoding="utf-8")
     ok = shadow_init.init_shadow(str(tmp_git_repo), reset=True, dry_run=True)
     assert ok is True
     # Original .shadow contents untouched
-    assert (tmp_git_repo / ".shadow" / "keep.txt").read_text() == "preserved\n"
+    assert (tmp_git_repo / ".shadow" / "keep.txt").read_text(encoding="utf-8") == "preserved\n"
     out = capsys.readouterr().out.lower()
     assert "would delete" in out
 
@@ -1381,14 +1382,14 @@ def test_init_shadow_dry_run_with_existing_shadow_and_reset(shadow_init,
 def test_init_shadow_skips_excluded_paths_and_basenames(shadow_init,
                                                        tmp_git_repo):
     """node_modules/, *.lock, *.min.js are filtered by built-in rules."""
-    (tmp_git_repo / "real.py").write_text("def x(): pass\n")
+    (tmp_git_repo / "real.py").write_text("def x(): pass\n", encoding="utf-8")
     nm = tmp_git_repo / "node_modules"
     nm.mkdir()
-    (nm / "junk.js").write_text("function junk(){}\n")
-    (tmp_git_repo / "huge.lock").write_text("{}\n")
-    (tmp_git_repo / "min.min.js").write_text("var a=1;\n")
+    (nm / "junk.js").write_text("function junk(){}\n", encoding="utf-8")
+    (tmp_git_repo / "huge.lock").write_text("{}\n", encoding="utf-8")
+    (tmp_git_repo / "min.min.js").write_text("var a=1;\n", encoding="utf-8")
     # Non-source file (no recognized extension)
-    (tmp_git_repo / "README.txt").write_text("docs\n")
+    (tmp_git_repo / "README.txt").write_text("docs\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1402,14 +1403,14 @@ def test_init_shadow_skips_excluded_paths_and_basenames(shadow_init,
     assert not (shadow / "min.min.js.md").exists()
     assert not (shadow / "README.txt.md").exists()
 
-    state = json.loads((shadow / "_meta" / "state.json").read_text())
+    state = json.loads((shadow / "_meta" / "state.json").read_text(encoding="utf-8"))
     assert state["total_files"] == 1
 
 
 def test_init_shadow_special_basenames_detected(shadow_init, tmp_git_repo):
     """Dockerfile and Makefile (basename-keyed languages) get shadows too."""
-    (tmp_git_repo / "Dockerfile").write_text("FROM scratch\n")
-    (tmp_git_repo / "Makefile").write_text("all:\n\techo hi\n")
+    (tmp_git_repo / "Dockerfile").write_text("FROM scratch\n", encoding="utf-8")
+    (tmp_git_repo / "Makefile").write_text("all:\n\techo hi\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1418,20 +1419,20 @@ def test_init_shadow_special_basenames_detected(shadow_init, tmp_git_repo):
     shadow = tmp_git_repo / ".shadow"
     assert (shadow / "Dockerfile.md").is_file()
     assert (shadow / "Makefile.md").is_file()
-    docker_md = (shadow / "Dockerfile.md").read_text()
+    docker_md = (shadow / "Dockerfile.md").read_text(encoding="utf-8")
     assert "Dockerfile" in docker_md
 
 
 def test_init_shadow_handles_unknown_language_file(shadow_init, tmp_git_repo):
     """A YAML file is recognized as a source file but has no extractor —
     a shadow is still created (with File-Level only, no symbols)."""
-    (tmp_git_repo / "config.yaml").write_text("key: value\n")
+    (tmp_git_repo / "config.yaml").write_text("key: value\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
 
     shadow_init.init_shadow(str(tmp_git_repo))
-    content = (tmp_git_repo / ".shadow" / "config.yaml.md").read_text()
+    content = (tmp_git_repo / ".shadow" / "config.yaml.md").read_text(encoding="utf-8")
     assert "YAML" in content
     assert "## File-Level" in content
     assert "## Cross-References" in content
@@ -1449,7 +1450,7 @@ def test_init_shadow_returns_true_with_no_source_files(shadow_init,
 
 def test_init_shadow_summary_printed_to_stdout(shadow_init, tmp_git_repo,
                                                capsys):
-    (tmp_git_repo / "a.py").write_text("def x(): pass\n")
+    (tmp_git_repo / "a.py").write_text("def x(): pass\n", encoding="utf-8")
     subprocess.run(["git", "add", "-A"], cwd=tmp_git_repo, check=True)
     subprocess.run(["git", "commit", "-q", "-m", "m"],
                    cwd=tmp_git_repo, check=True)
@@ -1507,7 +1508,7 @@ def test_main_nonexistent_root_exits_one(shadow_init, tmp_path, monkeypatch,
 def test_main_root_pointing_to_file_exits_one(shadow_init, tmp_path,
                                               monkeypatch):
     f = tmp_path / "regular.txt"
-    f.write_text("x")
+    f.write_text("x", encoding="utf-8")
     monkeypatch.setattr(sys, "argv", ["shadow-init.py", "--root", str(f)])
     with pytest.raises(SystemExit) as exc:
         shadow_init.main()
@@ -1560,7 +1561,7 @@ def test_main_refuses_when_shadow_exists_without_reset(shadow_init,
 def test_main_reset_replaces_existing_shadow(shadow_init, tmp_git_repo,
                                              monkeypatch):
     (tmp_git_repo / ".shadow").mkdir()
-    (tmp_git_repo / ".shadow" / "stale").write_text("old\n")
+    (tmp_git_repo / ".shadow" / "stale").write_text("old\n", encoding="utf-8")
     monkeypatch.setattr(sys, "argv",
                         ["shadow-init.py", "--root", str(tmp_git_repo),
                          "--reset"])
@@ -1580,7 +1581,7 @@ def test_main_with_coupon_demo_reset(shadow_init, coupon_demo, monkeypatch):
         shadow_init.main()
     assert exc.value.code == 0
     state = json.loads(
-        (coupon_demo / ".shadow" / "_meta" / "state.json").read_text()
+        (coupon_demo / ".shadow" / "_meta" / "state.json").read_text(encoding="utf-8")
     )
     assert state["version"] == 1
     assert state["last_update_type"] == "init"
@@ -1599,6 +1600,7 @@ def test_subprocess_main_block_via_cli_help():
     result = subprocess.run(
         [sys.executable, str(SCRIPT), "--help"],
         capture_output=True, text=True, timeout=30,
+        encoding="utf-8",
     )
     assert result.returncode == 0
     assert "usage" in result.stdout.lower()

--- a/tests/skills/shadow_frog_meditate/test_meditate_repair.py
+++ b/tests/skills/shadow_frog_meditate/test_meditate_repair.py
@@ -20,9 +20,9 @@ def make_dream(dreams_dir: Path, did: str, *, report: str = "", manifest: dict |
     d = dreams_dir / did
     d.mkdir(parents=True, exist_ok=True)
     if report:
-        (d / "report.md").write_text(report)
+        (d / "report.md").write_text(report, encoding="utf-8")
     if manifest is not None:
-        (d / "manifest.json").write_text(json.dumps(manifest))
+        (d / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
     return d
 
 
@@ -34,7 +34,7 @@ def make_index(dreams_dir: Path, rows: list[str]) -> Path:
     )
     content = header + "\n".join(rows) + "\n"
     index_path = dreams_dir / "_index.md"
-    index_path.write_text(content)
+    index_path.write_text(content, encoding="utf-8")
     return index_path
 
 
@@ -80,7 +80,7 @@ class TestLookupVerdict:
         did = "20250101-120000Z-v"
         d = tmp_path / did
         d.mkdir()
-        (d / "manifest.json").write_text(json.dumps({"verdict": "useful"}))
+        (d / "manifest.json").write_text(json.dumps({"verdict": "useful"}), encoding="utf-8")
 
         result = meditate_repair.lookup_verdict(str(d), "")
         assert result == "useful"
@@ -112,7 +112,7 @@ class TestLookupVerdict:
         did = "20250101-120000Z-bad"
         d = tmp_path / did
         d.mkdir()
-        (d / "manifest.json").write_text("not json")
+        (d / "manifest.json").write_text("not json", encoding="utf-8")
         content = "## Verdict\nThis is useful and verified."
         result = meditate_repair.lookup_verdict(str(d), content)
         assert result == "useful"
@@ -329,6 +329,7 @@ class TestCLI:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--help"],
             capture_output=True, text=True,
+            encoding="utf-8",
         )
         assert result.returncode == 0
 
@@ -361,12 +362,13 @@ class TestCLI:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--shadow-dir", str(shadow)],
             capture_output=True, text=True,
+            encoding="utf-8",
         )
         assert result.returncode == 0, f"stderr: {result.stderr}"
         assert "Repaired" in result.stdout
 
         # Verify the index was actually fixed
-        repaired_content = (dreams / "_index.md").read_text()
+        repaired_content = (dreams / "_index.md").read_text(encoding="utf-8")
         assert "bug hunting" in repaired_content
         assert "Real Title" in repaired_content
 
@@ -375,6 +377,7 @@ class TestCLI:
         result = subprocess.run(
             [sys.executable, str(SCRIPT), "--shadow-dir", str(coupon_demo / ".shadow")],
             capture_output=True, text=True,
+            encoding="utf-8",
         )
         assert result.returncode == 0
         # Should say "Repaired 0 rows"

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -37,14 +37,14 @@ def test_coupon_demo_copy_is_independent(coupon_demo, coupon_demo_src):
     assert coupon_demo != coupon_demo_src
     assert (coupon_demo / ".shadow" / "_index.md").is_file()
     # Mutate the copy and confirm the source is untouched.
-    (coupon_demo / "cart.py").write_text("# mutated by test\n")
-    assert (coupon_demo_src / "cart.py").read_text() != "# mutated by test\n"
+    (coupon_demo / "cart.py").write_text("# mutated by test\n", encoding="utf-8")
+    assert (coupon_demo_src / "cart.py").read_text(encoding="utf-8") != "# mutated by test\n"
 
 
 def test_coupon_demo_is_git_repo(coupon_demo):
     out = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=coupon_demo,
-        capture_output=True, text=True, check=True,
+        capture_output=True, text=True, check=True, encoding="utf-8",
     )
     assert len(out.stdout.strip()) == 40
 
@@ -55,6 +55,6 @@ def test_tmp_git_repo_is_empty(tmp_git_repo):
     # No commits yet
     result = subprocess.run(
         ["git", "rev-parse", "HEAD"], cwd=tmp_git_repo,
-        capture_output=True, text=True,
+        capture_output=True, text=True, encoding="utf-8",
     )
     assert result.returncode != 0  # HEAD doesn't exist


### PR DESCRIPTION
## Why

Follow-on to #17. On Windows the default text codec is `cp1252`, which can't encode the glyphs these tools emit (`✓ ❌ ⚠️ 🗑`) and can't decode the UTF-8 bytes they read back (e.g. the frog `🐸` = `F0 9F 90 B8`; byte `0x90` is undefined in `cp1252`). #17 fixed the three helpers that *crashed*; this PR finishes the job for the **stable** part of the tree.

Concretely on Windows, `dream-reconcile.py` crashes mid-output when run under a pipe (CI, a shell pipe, or pytest's subprocess), which fails 5 CLI tests:

- `test_cli_full_happy_path_reconciles_two_dreams`
- `test_cli_skips_invalid_manifest_and_continues`
- `test_cli_verify_only_passes_for_fully_reconciled_dream`
- `test_cli_verify_only_reports_missing_artifacts`
- `test_cli_cleanup_branches_after_reconcile`

The other helpers in this PR (`dream-coverage`, `meditate-repair`, `shadow-init`) don't fail current tests, but they read shadow files and git output that routinely contain emoji; on Windows that read raises `UnicodeDecodeError`. Pinning UTF-8 closes that latent crash too.

## What

- All four CLI entry points (`dream-reconcile.py`, `dream-coverage.py`, `meditate-repair.py`, `shadow-init.py`) get a `sys.stdout/stderr.reconfigure(encoding="utf-8")` guard at `main()` (same pattern as #17). It's required for `dream-reconcile` (which crashes today) and defensive for the other three (so any non-ASCII they print later, or that they already print like coverage's em-dash, stays UTF-8 across a pipe).
- Every text `open` / `read_text` / `write_text` and every `subprocess(..., text=True)` in those four files gets `encoding="utf-8"`.
- Tests: pin `encoding="utf-8"` on the matching subprocess/file sites so output round-trips as UTF-8 on a narrow-codec host.

This is part of a broader effort to pin UTF-8 at every text boundary across the codebase. Files that are deleted or ported to Python in later Windows-port phases (the bash/hook test suites) are intentionally left out of this PR and handled when those files are rewritten.

## Out of scope (tracked separately)

- Worktree-safety path handling on Windows (the `_worktree_safety.py` "path is not absolute" failures) — a later Windows-port phase.
- Emitting forward-slash paths in shadow artifacts (a couple of tests expect `/` but get OS-native `\`) — a path-normalization follow-up.

## Testing

- Linux CI: the pins are no-ops where the locale is already UTF-8, so nothing regresses.
- Locally on Windows: the 5 `cp1252` tests above now pass; `dream-coverage` / `meditate-repair` / smoke stay green; an AST scan reports 0 unencoded text-I/O sites in the touched files.

Part of #7
Closes #18

_Co-authored with Copilot 🤖_
