### PR TITLE
ci: run pytest on Windows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,9 +9,12 @@ permissions:
 
 jobs:
   pytest:
-    name: pytest (Python 3.12)
-    runs-on: ubuntu-latest
+    name: pytest (${{ matrix.os }}, Python 3.12)
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 10
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
 
     steps:
       - name: Checkout
@@ -30,17 +33,12 @@ jobs:
           pip install -r requirements-dev.txt
 
       - name: Run pytest with coverage
-        run: |
-          python -m pytest \
-            --cov=skills \
-            --cov-report=term \
-            --cov-report=xml \
-            -q
+        run: python -m pytest --cov=skills --cov-report=term --cov-report=xml -q
 
       - name: Upload coverage report
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: coverage-report
+          name: coverage-report-${{ matrix.os }}
           path: coverage.xml
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary
- run the pytest job on Ubuntu and Windows
- use a cross-platform pytest command
- give each OS a unique coverage artifact name

This adds Windows CI coverage needed to exercise the platform-specific path safety tests introduced in #20.